### PR TITLE
fix: CUDA/Metal kernel warmup, model migration, and error handling

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "murmur-voice"
 version = "0.1.0"
-description = "Privacy-first local voice-to-text for macOS"
+description = "Privacy-first local voice-to-text"
 authors = ["panda"]
 edition = "2021"
 


### PR DESCRIPTION
## Summary

- **CUDA/Metal kernel warmup**: Run a 1-second dummy inference at engine startup to pre-compile GPU kernels. Eliminates the severe first-transcription delay (was 10-30s+ with loud fan, now instant ~5x realtime from the start).
- **Windows model path migration**: Auto-migrate model from old macOS-style path (`$HOME/Library/Application Support/...`) to correct `%APPDATA%\murmur-voice\models\` path, with cross-drive copy+delete fallback and proper error logging.
- **Safer error handling**: Replace `expect()`/panic on missing env vars with graceful fallbacks; emit `recording_error` event and hide windows on recording failure in both toggle and hold modes; fix TOCTOU race condition in migration logic.
- **Minor cleanups**: Rename `use_local_engine` → `enable_live_preview` for clarity; remove macOS-specific description from Cargo.toml; remove unused `dirs_next()` helper.

## Context

After the Windows CUDA support was added in 31c5890, the first transcription after app launch was extremely slow due to CUDA kernel JIT compilation. This PR adds a warmup step that resolves the issue completely.

Tested on Windows 11 with NVIDIA GeForce RTX 4060 (CUDA 12.6, driver 561.17):
- Warmup completes in background during app startup
- First real transcription: 4.5s audio → 0.82s (5.5x realtime)
- No perceptible fan noise during normal use

## Test plan

- [ ] Launch app on Windows with CUDA GPU — verify first recording transcribes quickly without delay
- [ ] Launch app on macOS with Metal — verify warmup doesn't break Metal path
- [ ] Verify model migration works for users who had model at old macOS-style path on Windows
- [ ] Test recording error handling in both toggle and hold modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)