### PR TITLE
🔒 Disable macOS Private API usage

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ cuda = ["whisper-rs/cuda"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["macos-private-api", "tray-icon"] }
+tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-opener = "2"
 tauri-plugin-global-shortcut = "2"
 cpal = "0.15"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,6 @@
     "frontendDist": "../src"
   },
   "app": {
-    "macOSPrivateApi": true,
     "withGlobalTauri": true,
     "windows": [
       {


### PR DESCRIPTION
🎯 **What:** Disabled `macOSPrivateApi` in `src-tauri/tauri.conf.json` and removed the `macos-private-api` feature flag from `src-tauri/Cargo.toml`.
⚠️ **Risk:** Enabling private APIs can lead to App Store rejection and potential security vulnerabilities if exploited.
🛡️ **Solution:** Removed the configuration and feature flag to ensure compliance and security. The application targets macOS 12.0+, which supports standard transparency without private APIs.

---
*PR created automatically by Jules for task [7624176362675280259](https://jules.google.com/task/7624176362675280259) started by @panda850819*