### PR TITLE
🧹 Propagate errors in `peek_samples` instead of masking them

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -163,7 +163,10 @@ fn do_start_recording(app: &tauri::AppHandle) -> Result<(), String> {
                         Err(_) => break,
                     };
                     match lock.as_ref() {
-                        Some(rec) => rec.peek_samples(),
+                        Some(rec) => rec.peek_samples().unwrap_or_else(|e| {
+                            log::warn!("failed to peek samples: {}", e);
+                            Vec::new()
+                        }),
                         None => break,
                     }
                 };


### PR DESCRIPTION
This PR addresses an error masking issue in `AudioRecorder::peek_samples`. Previously, if the mutex lock on audio samples was poisoned, the error was silently swallowed, returning an empty vector. This change modifies `peek_samples` to return a `Result`, forcing the caller to handle the error. The call site in the live preview thread now logs a warning upon failure, improving observability while maintaining application stability (it continues to retry).

---
*PR created automatically by Jules for task [2947775424073439085](https://jules.google.com/task/2947775424073439085) started by @panda850819*