### PR TITLE
🧹 Improve error handling in LLM module to prevent masking response body errors

### DIFF
--- a/src-tauri/src/llm.rs
+++ b/src-tauri/src/llm.rs
@@ -89,9 +89,8 @@ CRITICAL: Output ONLY the cleaned transcription. Nothing else. No explanations, 
 
 /// Returns true if the text contains CJK characters.
 fn has_cjk(text: &str) -> bool {
-    text.chars().any(|c| {
-        matches!(c as u32, 0x4E00..=0x9FFF | 0x3400..=0x4DBF | 0xF900..=0xFAFF)
-    })
+    text.chars()
+        .any(|c| matches!(c as u32, 0x4E00..=0x9FFF | 0x3400..=0x4DBF | 0xF900..=0xFAFF))
 }
 
 /// In mixed CJK+English text, replaces English words with numbered placeholders
@@ -266,7 +265,9 @@ impl TextEnhancer for OpenAICompatibleEnhancer {
 
         if !response.status().is_success() {
             let status = response.status();
-            let body_text = rt.block_on(response.text()).unwrap_or_default();
+            let body_text = rt
+                .block_on(response.text())
+                .unwrap_or_else(|e| format!("(failed to read body: {e})"));
             return Err(LlmError::Api(format!("{status}: {body_text}")));
         }
 
@@ -293,7 +294,9 @@ impl TextEnhancer for OpenAICompatibleEnhancer {
 
 /// Creates the appropriate TextEnhancer based on current settings.
 /// Returns None if LLM is disabled or required config is missing.
-pub(crate) fn create_enhancer(settings: &crate::settings::Settings) -> Option<Box<dyn TextEnhancer>> {
+pub(crate) fn create_enhancer(
+    settings: &crate::settings::Settings,
+) -> Option<Box<dyn TextEnhancer>> {
     if !settings.llm_enabled {
         return None;
     }
@@ -393,7 +396,10 @@ pub(crate) async fn transcribe_groq(
 
     if !response.status().is_success() {
         let status = response.status();
-        let body_text = response.text().await.unwrap_or_default();
+        let body_text = response
+            .text()
+            .await
+            .unwrap_or_else(|e| format!("(failed to read body: {e})"));
         return Err(LlmError::Api(format!("{status}: {body_text}")));
     }
 
@@ -461,7 +467,10 @@ mod tests {
         let enhancer = OpenAICompatibleEnhancer::groq("test-key", "llama-3.3-70b-versatile");
         assert_eq!(enhancer.name(), "Groq");
         assert!(!enhancer.is_local());
-        assert_eq!(enhancer.api_url, "https://api.groq.com/openai/v1/chat/completions");
+        assert_eq!(
+            enhancer.api_url,
+            "https://api.groq.com/openai/v1/chat/completions"
+        );
     }
 
     #[test]
@@ -469,7 +478,10 @@ mod tests {
         let enhancer = OpenAICompatibleEnhancer::ollama("http://localhost:11434", "llama3.2");
         assert_eq!(enhancer.name(), "Ollama");
         assert!(enhancer.is_local());
-        assert_eq!(enhancer.api_url, "http://localhost:11434/v1/chat/completions");
+        assert_eq!(
+            enhancer.api_url,
+            "http://localhost:11434/v1/chat/completions"
+        );
     }
 
     #[test]


### PR DESCRIPTION
This PR addresses a code health issue where errors during reading of the HTTP response body in `src-tauri/src/llm.rs` were being masked by `unwrap_or_default()`, resulting in empty error messages.

The fix involves using `unwrap_or_else` to capture and format the error if reading the body fails. This change was applied to both the `enhance` function and the `transcribe_groq` function for consistency.

I have verified the changes by manual code review and syntax check (`cargo check` passed up to the point of system dependency failures which are expected in this environment). `cargo fmt` was also run on the modified file.

---
*PR created automatically by Jules for task [4897336771378730794](https://jules.google.com/task/4897336771378730794) started by @panda850819*