### PR TITLE
Extract UI dimensions into named constants in lib.rs

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,13 @@ use std::sync::Mutex;
 use std::time::Instant;
 use tauri::{Emitter, Manager};
 
+// UI Dimensions
+const PREVIEW_WINDOW_HEIGHT: f64 = 280.0;
+const PREVIEW_WINDOW_GAP: f64 = 8.0;
+const MAIN_WINDOW_WIDTH: f64 = 420.0;
+const MAIN_WINDOW_HEIGHT: f64 = 48.0;
+const MAIN_WINDOW_BOTTOM_MARGIN: f64 = 80.0;
+
 pub(crate) struct MurmurState {
     app_data_dir: PathBuf,
     app_state: state::AppState,
@@ -60,8 +67,8 @@ fn show_preview_window(app: &tauri::AppHandle) {
         // Position preview directly above the main bar
         if let Some(main_win) = app.get_webview_window("main") {
             if let Ok(main_pos) = main_win.outer_position() {
-                let preview_h = 280.0;
-                let gap = 8.0;
+                let preview_h = PREVIEW_WINDOW_HEIGHT;
+                let gap = PREVIEW_WINDOW_GAP;
                 let scale = main_win
                     .current_monitor()
                     .ok()
@@ -798,9 +805,9 @@ pub fn run() {
                 if let Some(monitor) = window.current_monitor().ok().flatten() {
                     let screen = monitor.size();
                     let scale = monitor.scale_factor();
-                    let win_w = 420.0;
-                    let win_h = 48.0;
-                    let margin = 80.0;
+                    let win_w = MAIN_WINDOW_WIDTH;
+                    let win_h = MAIN_WINDOW_HEIGHT;
+                    let margin = MAIN_WINDOW_BOTTOM_MARGIN;
                     let x = (screen.width as f64 / scale - win_w) / 2.0;
                     let y = screen.height as f64 / scale - win_h - margin;
                     use tauri::PhysicalPosition;
@@ -817,8 +824,8 @@ pub fn run() {
                 app.get_webview_window("preview"),
             ) {
                 if let Ok(main_pos) = main_win.outer_position() {
-                    let preview_h = 280.0;
-                    let gap = 8.0;
+                    let preview_h = PREVIEW_WINDOW_HEIGHT;
+                    let gap = PREVIEW_WINDOW_GAP;
                     let scale = main_win
                         .current_monitor()
                         .ok()


### PR DESCRIPTION
This change extracts UI dimensions into named constants in `src-tauri/src/lib.rs` to address the code health issue of magic numbers.

The following constants were added:
- `PREVIEW_WINDOW_HEIGHT`: 280.0
- `PREVIEW_WINDOW_GAP`: 8.0
- `MAIN_WINDOW_WIDTH`: 420.0
- `MAIN_WINDOW_HEIGHT`: 48.0
- `MAIN_WINDOW_BOTTOM_MARGIN`: 80.0

These constants replace the hardcoded values in `show_preview_window` and the `run` setup closure.

Verification:
- Manually verified that the values match the original magic numbers.
- Verified that the syntax is correct.
- `cargo clippy` was attempted but failed due to expected missing system dependencies in the environment.

---
*PR created automatically by Jules for task [2036727061286017079](https://jules.google.com/task/2036727061286017079) started by @panda850819*