### PR TITLE
🔒 Fix Weak CSP: Remove unsafe-inline from style-src

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -35,7 +35,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://cdn.buymeacoffee.com; connect-src 'self' https://api.groq.com https://huggingface.co https://*.huggingface.co http://localhost:11434"
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://cdn.buymeacoffee.com; connect-src 'self' https://api.groq.com https://huggingface.co https://*.huggingface.co http://localhost:11434"
     }
   },
   "bundle": {

--- a/src/index.html
+++ b/src/index.html
@@ -15,7 +15,7 @@
       <span id="status-text" class="status-text">Initializing...</span>
       <span id="app-badge" class="app-badge"></span>
       <span id="transcription" class="transcription"></span>
-      <div id="progress-container" class="progress-container" style="display: none;">
+      <div id="progress-container" class="progress-container hidden">
         <div id="progress-bar" class="progress-bar"></div>
       </div>
     </div>

--- a/src/main.js
+++ b/src/main.js
@@ -35,13 +35,13 @@ window.addEventListener("DOMContentLoaded", async () => {
   await listen(EVENTS.MODEL_DOWNLOAD_PROGRESS, (event) => {
     const { downloaded, total } = event.payload;
     const pct = total > 0 ? (downloaded / total) * 100 : 0;
-    progressContainer.style.display = "block";
+    progressContainer.classList.remove("hidden");
     progressBar.style.width = pct + "%";
     setStatus(null, t("state.downloadingModel").replace("{pct}", Math.round(pct)));
   });
 
   await listen(EVENTS.MODEL_READY, () => {
-    progressContainer.style.display = "none";
+    progressContainer.classList.add("hidden");
     progressBar.style.width = "0%";
     setStatus(null, t("state.ready"));
   });
@@ -136,7 +136,7 @@ window.addEventListener("DOMContentLoaded", async () => {
   } catch (_) {}
 
   if (!modelReady) {
-    progressContainer.style.display = "block";
+    progressContainer.classList.remove("hidden");
     setStatus(null, t("state.downloadingModel").replace(" {pct}%", ""));
     // Fire and forget — progress updates come via events above.
     invoke("download_model_cmd").catch((err) => {

--- a/src/onboarding.css
+++ b/src/onboarding.css
@@ -397,3 +397,7 @@ h1 {
   opacity: 1;
   transform: scale(1.2);
 }
+
+
+/* Utility */
+.hidden { display: none !important; }

--- a/src/onboarding.html
+++ b/src/onboarding.html
@@ -111,7 +111,7 @@
             <span class="engine-card-desc" data-i18n="onboard.engineGroqDesc">Fast, no download needed</span>
           </button>
         </div>
-        <div id="groq-key-wrap" class="groq-key-wrap" style="display:none;">
+        <div id="groq-key-wrap" class="groq-key-wrap hidden">
           <input id="onboard-groq-key" type="text" data-i18n="onboard.apiKeyPlaceholder" placeholder="Groq API Key (gsk_...)" />
         </div>
         <div class="step-actions">
@@ -134,7 +134,7 @@
           Whisper large-v3-turbo model for accurate local transcription.
         </p>
         <div id="model-status" class="model-status">
-          <div id="model-progress-wrap" class="progress-wrap" style="display: none;">
+          <div id="model-progress-wrap" class="progress-wrap hidden">
             <div class="progress-track">
               <div id="model-progress-bar" class="progress-bar"></div>
             </div>
@@ -144,7 +144,7 @@
         </div>
         <div class="step-actions">
           <button class="btn ghost back-btn" data-back="3" data-i18n="onboard.back">Back</button>
-          <button id="btn-step4-next" class="btn primary next-btn" data-next="5" style="display: none;" data-i18n="onboard.next">Next</button>
+          <button id="btn-step4-next" class="btn primary next-btn hidden" data-next="5" data-i18n="onboard.next">Next</button>
         </div>
       </div>
 

--- a/src/onboarding.js
+++ b/src/onboarding.js
@@ -58,7 +58,7 @@ function goToStep(n) {
 function updateDots() {
   const dot4 = document.querySelector('.dot[data-dot="4"]');
   if (dot4) {
-    dot4.style.display = chosenEngine === "groq" ? "none" : "";
+    dot4.classList.toggle("hidden", chosenEngine === "groq");
   }
 }
 
@@ -153,7 +153,7 @@ window.addEventListener("DOMContentLoaded", async () => {
       document.querySelectorAll(".engine-card").forEach((c) => c.classList.remove("active"));
       card.classList.add("active");
       chosenEngine = card.dataset.engine;
-      el("groq-key-wrap").style.display = chosenEngine === "groq" ? "" : "none";
+      el("groq-key-wrap").classList.toggle("hidden", chosenEngine !== "groq");
       updateEngineNext();
       updateDots();
     });
@@ -174,20 +174,20 @@ window.addEventListener("DOMContentLoaded", async () => {
   // Step 4: Model download
   const modelReady = await invoke("is_model_ready");
   if (modelReady) {
-    el("btn-download").style.display = "none";
-    el("btn-step4-next").style.display = "";
+    el("btn-download").classList.add("hidden");
+    el("btn-step4-next").classList.remove("hidden");
   }
 
   el("btn-download").addEventListener("click", async () => {
     el("btn-download").disabled = true;
     el("btn-download").textContent = t("onboard.downloading");
-    el("model-progress-wrap").style.display = "flex";
+    el("model-progress-wrap").classList.remove("hidden");
 
     try {
       await invoke("download_model_cmd");
-      el("model-progress-wrap").style.display = "none";
-      el("btn-download").style.display = "none";
-      el("btn-step4-next").style.display = "";
+      el("model-progress-wrap").classList.add("hidden");
+      el("btn-download").classList.add("hidden");
+      el("btn-step4-next").classList.remove("hidden");
     } catch (e) {
       el("btn-download").disabled = false;
       el("btn-download").textContent = t("onboard.retryDownload");

--- a/src/preview.css
+++ b/src/preview.css
@@ -252,3 +252,7 @@ html, body {
 }
 
 /* Processing state handled by JS (appends animated dots to header text) */
+
+
+/* Utility */
+.hidden { display: none !important; }

--- a/src/preview.html
+++ b/src/preview.html
@@ -20,14 +20,14 @@
       <div id="preview-footer" class="preview-footer">
         <span id="char-count" class="char-count"></span>
         <div class="footer-actions">
-          <button id="copy-btn" class="copy-btn" data-i18n="preview.copy" style="display:none;">Copy</button>
+          <button id="copy-btn" class="copy-btn hidden" data-i18n="preview.copy">Copy</button>
         </div>
         <span id="app-badge" class="app-badge"></span>
       </div>
-      <div id="dict-suggest" class="dict-suggest" style="display:none;">
+      <div id="dict-suggest" class="dict-suggest hidden">
         <div id="dict-chips" class="dict-chips"></div>
         <div class="dict-suggest-actions">
-          <button id="dict-add-all-btn" class="dict-btn dict-add" data-i18n="preview.addAll" style="display:none;">Add All</button>
+          <button id="dict-add-all-btn" class="dict-btn dict-add hidden" data-i18n="preview.addAll">Add All</button>
           <button id="dict-dismiss-btn" class="dict-btn dict-dismiss" data-i18n="preview.dismiss">Dismiss</button>
         </div>
       </div>

--- a/src/preview.js
+++ b/src/preview.js
@@ -122,8 +122,8 @@ function showDictSuggestions(words) {
     container.appendChild(chip);
   });
   const addAllBtn = document.getElementById("dict-add-all-btn");
-  addAllBtn.style.display = words.length >= 2 ? "" : "none";
-  dictSuggest().style.display = "";
+  addAllBtn.classList.toggle("hidden", words.length < 2);
+  dictSuggest().classList.remove("hidden");
 }
 
 async function addDictWord(word, chipEl) {
@@ -154,11 +154,11 @@ function updateDictBar() {
     return;
   }
   const addAllBtn = document.getElementById("dict-add-all-btn");
-  addAllBtn.style.display = chips.length >= 2 ? "" : "none";
+  addAllBtn.classList.toggle("hidden", chips.length < 2);
 }
 
 function hideDictSuggest() {
-  dictSuggest().style.display = "none";
+  dictSuggest().classList.add("hidden");
   const container = dictChips();
   while (container.firstChild) container.removeChild(container.firstChild);
 }
@@ -174,7 +174,7 @@ function reset() {
   setCharCount("");
   setAppBadge(null);
   disableEditing();
-  copyBtn().style.display = "none";
+  copyBtn().classList.add("hidden");
   hideDictSuggest();
   currentMode = null;
   originalText = "";
@@ -314,7 +314,7 @@ window.addEventListener("DOMContentLoaded", async () => {
       setHeader(t("state.done"), false);
       setText(t("preview.noSpeech"), "no-speech");
       setCharCount("");
-      copyBtn().style.display = "none";
+      copyBtn().classList.add("hidden");
       disableEditing();
     } else {
       setHeader(t("state.done"), false);
@@ -322,7 +322,7 @@ window.addEventListener("DOMContentLoaded", async () => {
       setCharCount(text);
       scrollToBottom();
       originalText = text;
-      copyBtn().style.display = "";
+      copyBtn().classList.remove("hidden");
       enableEditing();
 
       // Auto-hide: 5s for pasted mode, cancelled by editing

--- a/src/settings.css
+++ b/src/settings.css
@@ -629,3 +629,7 @@ input[type="range"]::-webkit-slider-thumb:hover {
   box-shadow: none;
   text-decoration: underline;
 }
+
+
+/* Utility */
+.hidden { display: none !important; }

--- a/src/settings.html
+++ b/src/settings.html
@@ -68,7 +68,7 @@
               <option value="base">Base</option>
             </select>
           </div>
-          <div class="row groq-hint" id="groq-section" style="display: none;">
+          <div class="row groq-hint hidden" id="groq-section">
             <span class="row-label"></span>
             <span class="row-hint" data-i18n="hint.groqKey">API Key is in AI Processing below</span>
           </div>
@@ -81,7 +81,7 @@
               <div class="dict-tags" id="dict-tags"></div>
               <input type="text" id="dict-input" class="dict-input" placeholder="Type a term and press Enter" data-i18n="dict.placeholder" spellcheck="false" />
             </div>
-            <div id="dict-undo" class="dict-undo" style="display:none;">
+            <div id="dict-undo" class="dict-undo hidden">
               <span id="dict-undo-text" class="dict-undo-text"></span>
               <button id="dict-undo-btn" class="dict-undo-btn">Undo</button>
             </div>
@@ -100,7 +100,7 @@
             </label>
           </div>
           <div class="row-desc" data-i18n="hint.llm">Auto-clean filler words, add punctuation, fix grammar after transcription</div>
-          <div id="llm-settings" style="display: none;">
+          <div id="llm-settings" class="hidden">
             <div class="row">
               <span class="row-label" data-i18n="row.provider">Provider</span>
               <select id="llm-provider">
@@ -123,7 +123,7 @@
                 </select>
               </div>
             </div>
-            <div id="ollama-section" style="display: none;">
+            <div id="ollama-section" class="hidden">
               <div class="row-desc" data-i18n="hint.ollama">Runs locally, fully offline. Requires Ollama installed.</div>
               <div class="row">
                 <span class="row-label" data-i18n="row.url">URL</span>
@@ -134,7 +134,7 @@
                 <input type="text" id="ollama-model" placeholder="llama3.2" spellcheck="false" />
               </div>
             </div>
-            <div id="custom-llm-section" style="display: none;">
+            <div id="custom-llm-section" class="hidden">
               <div class="row">
                 <span class="row-label" data-i18n="row.endpoint">Endpoint</span>
                 <input type="text" id="custom-llm-url" placeholder="https://..." spellcheck="false" />

--- a/src/settings.js
+++ b/src/settings.js
@@ -130,20 +130,20 @@ function setRecordingMode(mode) {
 
 function updateEngineVisibility() {
   const isLocal = el("engine").value === "local";
-  el("model-section").style.display = isLocal ? "flex" : "none";
-  el("groq-section").style.display = isLocal ? "none" : "flex";
+  el("model-section").classList.toggle("hidden", !isLocal);
+  el("groq-section").classList.toggle("hidden", isLocal);
 }
 
 function updateLlmProviderVisibility() {
   const provider = el("llm-provider").value;
-  el("groq-llm-section").style.display = provider === "groq" ? "block" : "none";
-  el("ollama-section").style.display = provider === "ollama" ? "block" : "none";
-  el("custom-llm-section").style.display = provider === "custom" ? "block" : "none";
+  el("groq-llm-section").classList.toggle("hidden", provider !== "groq");
+  el("ollama-section").classList.toggle("hidden", provider !== "ollama");
+  el("custom-llm-section").classList.toggle("hidden", provider !== "custom");
 }
 
 function updateLlmVisibility() {
   const enabled = el("llm-enabled").checked;
-  el("llm-settings").style.display = enabled ? "block" : "none";
+  el("llm-settings").classList.toggle("hidden", !enabled);
   if (enabled) {
     updateLlmProviderVisibility();
   }
@@ -200,9 +200,9 @@ function showDictUndo(term, index) {
   undoEntry = { term, index };
   const container = el("dict-undo");
   el("dict-undo-text").textContent = t("dict.removedTerm").replace("{term}", term);
-  container.style.display = "flex";
+  container.classList.remove("hidden");
   undoTimer = setTimeout(() => {
-    container.style.display = "none";
+    container.classList.add("hidden");
     undoEntry = null;
     undoTimer = null;
   }, 4000);
@@ -215,7 +215,7 @@ function doDictUndo() {
   dictTags.splice(pos, 0, term);
   renderDictTags();
   if (undoTimer) clearTimeout(undoTimer);
-  el("dict-undo").style.display = "none";
+  el("dict-undo").classList.add("hidden");
   undoEntry = null;
   undoTimer = null;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -116,3 +116,7 @@ html, body {
     box-shadow: 0 0 8px 2px currentColor;
   }
 }
+
+
+/* Utility */
+.hidden { display: none !important; }


### PR DESCRIPTION
This PR addresses a security vulnerability by removing 'unsafe-inline' from the Content Security Policy's `style-src` directive. This change prevents the execution of inline styles, mitigating the risk of Cross-Site Scripting (XSS) attacks.

Changes include:
- Removing `'unsafe-inline'` from `src-tauri/tauri.conf.json`.
- Introducing a `.hidden` utility class in `styles.css`, `onboarding.css`, `preview.css`, and `settings.css`.
- Updating all HTML files to use the `.hidden` class instead of inline `style="display: none;"`.
- Updating all JavaScript files (`main.js`, `onboarding.js`, `preview.js`, `settings.js`) to manipulate the `.hidden` class for visibility toggling instead of modifying `element.style.display` directly.

The changes were verified using a Playwright script to ensuring that elements are correctly hidden and shown as expected, and that the layout is preserved.

---
*PR created automatically by Jules for task [16855890654093937128](https://jules.google.com/task/16855890654093937128) started by @panda850819*