### PR TITLE
🛡️ Sentinel: Fix insecure settings file creation (TOCTOU)

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 
 fn default_hold() -> String {
@@ -301,11 +301,27 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
 
     #[cfg(unix)]
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| e.to_string())?;
+    {
+        use std::io::Write;
+        let mut options = std::fs::OpenOptions::new();
+        options
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600);
+        let mut file = options.open(&path).map_err(|e| e.to_string())?;
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))
+            .map_err(|e| e.to_string())?;
+        file.write_all(json.as_bytes())
+            .map_err(|e| e.to_string())?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&path, json).map_err(|e| e.to_string())?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## 🛡️ Sentinel: [CRITICAL/HIGH] Fix Insecure File Creation (TOCTOU)

### 🚨 Severity: CRITICAL
The settings file (`settings.json`) stores sensitive API keys (Groq, Custom LLM).

### 💡 Vulnerability
The previous implementation used `std::fs::write` followed by `std::fs::set_permissions`. This creates a window where the file exists with default permissions (potentially world-readable depending on umask) before being restricted. An attacker could race to read the file during this window.

### 🎯 Impact
API keys could be leaked to other users on the same system if the umask is permissive (e.g., `022`).

### 🔧 Fix
Updated `save_settings` in `src-tauri/src/settings.rs` to use `std::fs::OpenOptions` with `.mode(0o600)` (via `std::os::unix::fs::OpenOptionsExt`) on Unix systems. This ensures the file is created with restrictive permissions atomically.
Also added `file.set_permissions(...)` to ensure existing files are also restricted.

### ✅ Verification
Verified with a standalone Rust script that `OpenOptions::mode(0o600)` results in `600` permissions on creation, whereas `fs::write` results in default permissions until changed.
Manual code review confirmed the logic handles both creation and existing files correctly.

---
*PR created automatically by Jules for task [5058349588524714396](https://jules.google.com/task/5058349588524714396) started by @panda850819*