### PR TITLE
🛡️ Sentinel: Fix insecure settings file creation (TOCTOU)

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -301,11 +301,31 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
 
     #[cfg(unix)]
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| e.to_string())?;
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&path)
+            .map_err(|e| e.to_string())?;
+
+        // Also enforce permissions on the open file handle to fix existing files
+        let mut perms = file.metadata().map_err(|e| e.to_string())?.permissions();
+        perms.set_mode(0o600);
+        file.set_permissions(perms).map_err(|e| e.to_string())?;
+
+        file.write_all(json.as_bytes())
+            .map_err(|e| e.to_string())?;
+    }
+
+    #[cfg(not(unix))]
+    std::fs::write(&path, json).map_err(|e| e.to_string())?;
 
     Ok(())
 }


### PR DESCRIPTION
This PR addresses a security vulnerability where the settings file was created with default permissions and then restricted, leaving a small window for unauthorized access. The fix uses `OpenOptions` to set permissions at creation time on Unix systems.

---
*PR created automatically by Jules for task [4344193200321455383](https://jules.google.com/task/4344193200321455383) started by @panda850819*