### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix sensitive data leakage in logs

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -429,7 +429,7 @@ fn do_stop_recording(app: &tauri::AppHandle) -> Result<String, String> {
         (llm::create_enhancer(&s), s.app_aware_style)
     };
 
-    eprintln!("[whisper raw] {}", raw_text);
+    log::debug!("[whisper raw] {}", raw_text);
 
     let text = if let Some(enhancer) = enhancer {
         if raw_text.is_empty() {
@@ -459,7 +459,7 @@ fn do_stop_recording(app: &tauri::AppHandle) -> Result<String, String> {
 
             match enhancer.enhance(&raw_text, style) {
                 Ok(processed) => {
-                    eprintln!("[llm output] {}", processed);
+                    log::debug!("[llm output] {}", processed);
                     processed
                 }
                 Err(e) => {


### PR DESCRIPTION
Replaced `eprintln!` calls with `log::debug!` in `src-tauri/src/lib.rs` to prevent raw voice transcriptions and LLM outputs from being printed to standard error. This prevents sensitive user data from being exposed in production logs. This change aligns with security best practices for handling sensitive user input.

---
*PR created automatically by Jules for task [8748743206472618815](https://jules.google.com/task/8748743206472618815) started by @panda850819*