### PR TITLE
🛡️ Sentinel: [HIGH] Fix sensitive data leak in standard error logs

### DIFF
--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -166,11 +166,13 @@ impl AudioRecorder {
                             // 1. Convert to Mono F32
                             if channels > 1 {
                                 for frame in data.chunks(channels as usize) {
-                                    let sum: f32 = frame.iter().map(|&s| s as f32 / i16::MAX as f32).sum();
+                                    let sum: f32 =
+                                        frame.iter().map(|&s| s as f32 / i16::MAX as f32).sum();
                                     intermediate.push(sum / channels as f32);
                                 }
                             } else {
-                                intermediate.extend(data.iter().map(|&s| s as f32 / i16::MAX as f32));
+                                intermediate
+                                    .extend(data.iter().map(|&s| s as f32 / i16::MAX as f32));
                             }
 
                             // 2. Resample or pass through
@@ -230,11 +232,7 @@ impl AudioRecorder {
             let _ = handle.join();
         }
 
-        let samples = self
-            .samples
-            .lock()
-            .expect("samples mutex poisoned")
-            .clone();
+        let samples = self.samples.lock().expect("samples mutex poisoned").clone();
 
         // Short recording protection
         if samples.len() < MIN_SAMPLES {
@@ -300,12 +298,12 @@ mod tests {
         assert!((output[0] - 0.0).abs() < 1e-6); // idx 0
         assert!((output[1] - 0.5).abs() < 1e-6); // idx 0.5
         assert!((output[2] - 1.0).abs() < 1e-6); // idx 1.0
-        // idx 1.5 -> src_idx 1. (idx+1 out of bounds). input[1] = 1.0.
-        // 1.0 * (1-0.5) + (out_of_bounds? no, logic says if src_idx < len returns input[src_idx])
-        // wait, logic says:
-        // if src_idx + 1 < input.len() { lerp }
-        // else if src_idx < input.len() { input[src_idx] }
-        // else { 0.0 }
+                                                 // idx 1.5 -> src_idx 1. (idx+1 out of bounds). input[1] = 1.0.
+                                                 // 1.0 * (1-0.5) + (out_of_bounds? no, logic says if src_idx < len returns input[src_idx])
+                                                 // wait, logic says:
+                                                 // if src_idx + 1 < input.len() { lerp }
+                                                 // else if src_idx < input.len() { input[src_idx] }
+                                                 // else { 0.0 }
 
         // i=3. src_pos = 1.5. src_idx=1. frac=0.5.
         // src_idx+1 = 2. input len is 2. 2 < 2 is false.

--- a/src-tauri/src/frontapp_macos.rs
+++ b/src-tauri/src/frontapp_macos.rs
@@ -36,7 +36,9 @@ pub(crate) fn foreground_app_bundle_id() -> Option<String> {
         // [nsString UTF8String]
         let sel_utf8 = sel_registerName(c"UTF8String".as_ptr());
         let msg_send_str: unsafe extern "C" fn(*mut Object, Sel) -> *const std::ffi::c_char =
-            std::mem::transmute(objc_msgSend as unsafe extern "C" fn(*mut Object, Sel) -> *mut Object);
+            std::mem::transmute(
+                objc_msgSend as unsafe extern "C" fn(*mut Object, Sel) -> *mut Object,
+            );
         let utf8_ptr: *const std::ffi::c_char = msg_send_str(ns_string, sel_utf8);
         if utf8_ptr.is_null() {
             return None;
@@ -233,8 +235,9 @@ pub(crate) fn is_microphone_authorized() -> bool {
         }
 
         let sel = sel_registerName(c"authorizationStatusForMediaType:".as_ptr());
-        let send: unsafe extern "C" fn(*const Object, Sel, CFTypeRef) -> i64 =
-            std::mem::transmute(objc_msgSend as unsafe extern "C" fn(*mut Object, Sel) -> *mut Object);
+        let send: unsafe extern "C" fn(*const Object, Sel, CFTypeRef) -> i64 = std::mem::transmute(
+            objc_msgSend as unsafe extern "C" fn(*mut Object, Sel) -> *mut Object,
+        );
         let status = send(class, sel, audio_type);
         // Don't CFRelease — audio_type is a framework constant, not an owned object
         log::info!("mic check: AVCaptureDevice authorizationStatus = {status}");

--- a/src-tauri/src/frontapp_windows.rs
+++ b/src-tauri/src/frontapp_windows.rs
@@ -1,6 +1,9 @@
 use windows::core::PWSTR;
 use windows::Win32::Foundation::CloseHandle;
-use windows::Win32::System::Com::{CoCreateInstance, CoInitializeEx, CoUninitialize, CLSCTX_INPROC_SERVER, COINIT_APARTMENTTHREADED};
+use windows::Win32::System::Com::{
+    CoCreateInstance, CoInitializeEx, CoUninitialize, CLSCTX_INPROC_SERVER,
+    COINIT_APARTMENTTHREADED,
+};
 use windows::Win32::System::Threading::{
     OpenProcess, QueryFullProcessImageNameW, PROCESS_NAME_FORMAT, PROCESS_QUERY_LIMITED_INFORMATION,
 };
@@ -30,7 +33,12 @@ pub(crate) fn foreground_app_bundle_id() -> Option<String> {
 
         let mut buf = [0u16; 1024];
         let mut len = buf.len() as u32;
-        let ok = QueryFullProcessImageNameW(process, PROCESS_NAME_FORMAT(0), PWSTR(buf.as_mut_ptr()), &mut len);
+        let ok = QueryFullProcessImageNameW(
+            process,
+            PROCESS_NAME_FORMAT(0),
+            PWSTR(buf.as_mut_ptr()),
+            &mut len,
+        );
         let _ = CloseHandle(process);
 
         if ok.is_err() {
@@ -39,10 +47,7 @@ pub(crate) fn foreground_app_bundle_id() -> Option<String> {
 
         let full_path = String::from_utf16_lossy(&buf[..len as usize]);
         // Extract just the filename from the full path
-        full_path
-            .rsplit('\\')
-            .next()
-            .map(|s| s.to_string())
+        full_path.rsplit('\\').next().map(|s| s.to_string())
     }
 }
 
@@ -85,9 +90,17 @@ pub(crate) fn style_for_app(exe_name: &str) -> &'static str {
         | "ms-teams.exe" => "casual",
 
         // Code editors / terminals
-        "code.exe" | "devenv.exe" | "idea64.exe" | "idea.exe" | "cursor.exe"
-        | "sublime_text.exe" | "windowsterminal.exe" | "wt.exe" | "cmd.exe"
-        | "powershell.exe" | "pwsh.exe" => "technical",
+        "code.exe"
+        | "devenv.exe"
+        | "idea64.exe"
+        | "idea.exe"
+        | "cursor.exe"
+        | "sublime_text.exe"
+        | "windowsterminal.exe"
+        | "wt.exe"
+        | "cmd.exe"
+        | "powershell.exe"
+        | "pwsh.exe" => "technical",
 
         _ => "default",
     }

--- a/src-tauri/src/hotkey_macos.rs
+++ b/src-tauri/src/hotkey_macos.rs
@@ -137,8 +137,7 @@ unsafe extern "C" fn event_tap_callback(
             }
         }
         K_CG_EVENT_KEY_DOWN => {
-            let keycode =
-                CGEventGetIntegerValueField(event, K_CG_KEYBOARD_EVENT_KEYCODE) as u32;
+            let keycode = CGEventGetIntegerValueField(event, K_CG_KEYBOARD_EVENT_KEYCODE) as u32;
             if keycode == regular_key
                 && MODIFIER_HELD.load(Ordering::SeqCst)
                 && !COMBO_ACTIVE.load(Ordering::SeqCst)
@@ -149,8 +148,7 @@ unsafe extern "C" fn event_tap_callback(
             }
         }
         K_CG_EVENT_KEY_UP => {
-            let keycode =
-                CGEventGetIntegerValueField(event, K_CG_KEYBOARD_EVENT_KEYCODE) as u32;
+            let keycode = CGEventGetIntegerValueField(event, K_CG_KEYBOARD_EVENT_KEYCODE) as u32;
             if keycode == regular_key && COMBO_ACTIVE.swap(false, Ordering::SeqCst) {
                 let _ = sender.send(HotkeyEvent::Released);
                 return std::ptr::null_mut(); // consume event
@@ -162,13 +160,10 @@ unsafe extern "C" fn event_tap_callback(
     event
 }
 
-pub(crate) fn start_listener(
-    sender: mpsc::Sender<HotkeyEvent>,
-) -> std::thread::JoinHandle<()> {
+pub(crate) fn start_listener(sender: mpsc::Sender<HotkeyEvent>) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || unsafe {
-        let event_mask: u64 = (1 << K_CG_EVENT_KEY_DOWN)
-            | (1 << K_CG_EVENT_KEY_UP)
-            | (1 << K_CG_EVENT_FLAGS_CHANGED);
+        let event_mask: u64 =
+            (1 << K_CG_EVENT_KEY_DOWN) | (1 << K_CG_EVENT_KEY_UP) | (1 << K_CG_EVENT_FLAGS_CHANGED);
 
         let sender_box = Box::new(sender);
         let sender_ptr = Box::into_raw(sender_box) as *mut c_void;

--- a/src-tauri/src/hotkey_windows.rs
+++ b/src-tauri/src/hotkey_windows.rs
@@ -116,9 +116,7 @@ unsafe extern "system" fn keyboard_hook_proc(
     CallNextHookEx(None, n_code, w_param, l_param)
 }
 
-pub(crate) fn start_listener(
-    sender: mpsc::Sender<HotkeyEvent>,
-) -> std::thread::JoinHandle<()> {
+pub(crate) fn start_listener(sender: mpsc::Sender<HotkeyEvent>) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || unsafe {
         GLOBAL_SENDER = Some(sender);
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -163,9 +163,7 @@ fn do_start_recording(app: &tauri::AppHandle) -> Result<(), String> {
         .map_err(|e| format!("recorder mutex poisoned: {e}"))?;
     *recorder_lock = Some(recorder);
 
-    let _ = state
-        .app_state
-        .transition(state::RecordingState::Recording);
+    let _ = state.app_state.transition(state::RecordingState::Recording);
     let _ = app.emit("recording_state_changed", "recording");
 
     // Auto-stop after 5 minutes in toggle mode
@@ -239,7 +237,9 @@ fn do_start_recording(app: &tauri::AppHandle) -> Result<(), String> {
                         }
                     };
                     match engine_lock.as_ref() {
-                        Some(engine) => engine.transcribe(&samples, &language, &initial_prompt).unwrap_or_default(),
+                        Some(engine) => engine
+                            .transcribe(&samples, &language, &initial_prompt)
+                            .unwrap_or_default(),
                         None => {
                             // Engine not ready yet — wait and retry on next loop iteration
                             drop(engine_lock);
@@ -321,7 +321,12 @@ fn do_stop_recording(app: &tauri::AppHandle) -> Result<String, String> {
         if app_aware {
             let (name, style) = frontapp::foreground_app_bundle_id()
                 .as_deref()
-                .map(|bid| (frontapp::display_name_for_app(bid), frontapp::style_for_app(bid)))
+                .map(|bid| {
+                    (
+                        frontapp::display_name_for_app(bid),
+                        frontapp::style_for_app(bid),
+                    )
+                })
                 .unwrap_or(("Unknown", "default"));
             let _ = app.emit(
                 "foreground_app_info",
@@ -333,18 +338,30 @@ fn do_stop_recording(app: &tauri::AppHandle) -> Result<String, String> {
     let (engine_type, language, initial_prompt, api_key_for_whisper) = state
         .settings
         .lock()
-        .map(|s| (
-            s.engine.clone(),
-            s.whisper_language().to_string(),
-            s.whisper_initial_prompt(),
-            s.groq_api_key.clone(),
-        ))
-        .unwrap_or_else(|_| ("local".to_string(), "auto".to_string(), String::new(), String::new()));
+        .map(|s| {
+            (
+                s.engine.clone(),
+                s.whisper_language().to_string(),
+                s.whisper_initial_prompt(),
+                s.groq_api_key.clone(),
+            )
+        })
+        .unwrap_or_else(|_| {
+            (
+                "local".to_string(),
+                "auto".to_string(),
+                String::new(),
+                String::new(),
+            )
+        });
 
     // Anti-hallucination: skip if audio is too short or silent (applies to all engines)
     const MIN_TRANSCRIBE_SAMPLES: usize = 16_000; // 1s at 16kHz
     if samples.len() < MIN_TRANSCRIBE_SAMPLES {
-        log::info!("audio too short ({} samples), skipping transcription", samples.len());
+        log::info!(
+            "audio too short ({} samples), skipping transcription",
+            samples.len()
+        );
         let _ = state.app_state.transition(state::RecordingState::Idle);
         let _ = app.emit("recording_state_changed", "idle");
         return Ok(String::new());
@@ -389,11 +406,14 @@ fn do_stop_recording(app: &tauri::AppHandle) -> Result<String, String> {
             .lock()
             .map_err(|e| format!("engine mutex poisoned: {e}"))?;
         match engine_lock.as_ref() {
-            Some(engine) => engine.transcribe(&samples, &language, &initial_prompt).map_err(|e| e.to_string())?,
+            Some(engine) => engine
+                .transcribe(&samples, &language, &initial_prompt)
+                .map_err(|e| e.to_string())?,
             None => {
                 // Engine not available — retry init synchronously (task 4.4)
                 drop(engine_lock);
-                let model_path = model::model_path(&state.app_data_dir, &model::ModelConfig::default().filename);
+                let model_path =
+                    model::model_path(&state.app_data_dir, &model::ModelConfig::default().filename);
                 let model_path_str = model_path
                     .to_str()
                     .ok_or("model path contains invalid UTF-8")?;
@@ -429,7 +449,7 @@ fn do_stop_recording(app: &tauri::AppHandle) -> Result<String, String> {
         (llm::create_enhancer(&s), s.app_aware_style)
     };
 
-    eprintln!("[whisper raw] {}", raw_text);
+    log::debug!("[whisper raw] {}", raw_text);
 
     let text = if let Some(enhancer) = enhancer {
         if raw_text.is_empty() {
@@ -459,7 +479,7 @@ fn do_stop_recording(app: &tauri::AppHandle) -> Result<String, String> {
 
             match enhancer.enhance(&raw_text, style) {
                 Ok(processed) => {
-                    eprintln!("[llm output] {}", processed);
+                    log::debug!("[llm output] {}", processed);
                     processed
                 }
                 Err(e) => {
@@ -551,7 +571,10 @@ async fn check_for_updates() -> Result<UpdateCheckResult, String> {
         .await
         .map_err(|e| format!("request failed: {e}"))?;
 
-    let json: serde_json::Value = resp.json().await.map_err(|e| format!("parse failed: {e}"))?;
+    let json: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("parse failed: {e}"))?;
     let tag = json["tag_name"].as_str().unwrap_or("unknown");
     let latest = tag.trim_start_matches('v');
     let url = json["html_url"]
@@ -591,15 +614,19 @@ async fn download_model_cmd(app: tauri::AppHandle) -> Result<(), String> {
     let base = murmur_state.app_data_dir.clone();
 
     let app_clone = app.clone();
-    model::download_model(&base, &model::ModelConfig::default(), move |downloaded, total| {
-        let _ = app_clone.emit(
-            "model_download_progress",
-            serde_json::json!({
-                "downloaded": downloaded,
-                "total": total,
-            }),
-        );
-    })
+    model::download_model(
+        &base,
+        &model::ModelConfig::default(),
+        move |downloaded, total| {
+            let _ = app_clone.emit(
+                "model_download_progress",
+                serde_json::json!({
+                    "downloaded": downloaded,
+                    "total": total,
+                }),
+            );
+        },
+    )
     .await
     .map_err(|e| e.to_string())?;
 
@@ -654,11 +681,7 @@ fn stop_recording(app: tauri::AppHandle) -> Result<String, String> {
 
 #[tauri::command]
 fn get_settings(state: tauri::State<'_, MurmurState>) -> settings::Settings {
-    state
-        .settings
-        .lock()
-        .map(|s| s.clone())
-        .unwrap_or_default()
+    state.settings.lock().map(|s| s.clone()).unwrap_or_default()
 }
 
 #[tauri::command]
@@ -750,10 +773,7 @@ fn resume_hotkey_listener(state: tauri::State<'_, MurmurState>) {
 }
 
 #[tauri::command]
-fn add_dictionary_term(
-    term: String,
-    state: tauri::State<'_, MurmurState>,
-) -> Result<(), String> {
+fn add_dictionary_term(term: String, state: tauri::State<'_, MurmurState>) -> Result<(), String> {
     let trimmed = term.trim();
     if trimmed.is_empty() {
         return Ok(());
@@ -797,10 +817,8 @@ fn add_dictionary_terms(
             .filter(|t| !t.is_empty())
             .collect();
 
-        let mut existing_set: std::collections::HashSet<String> = existing_vec
-            .iter()
-            .map(|t| t.to_lowercase())
-            .collect();
+        let mut existing_set: std::collections::HashSet<String> =
+            existing_vec.iter().map(|t| t.to_lowercase()).collect();
 
         let mut added = false;
         for term in terms {
@@ -846,8 +864,7 @@ fn open_settings(app: tauri::AppHandle) {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     #[allow(unused_mut)]
-    let mut builder = tauri::Builder::default()
-        .plugin(tauri_plugin_opener::init());
+    let mut builder = tauri::Builder::default().plugin(tauri_plugin_opener::init());
 
     #[cfg(target_os = "macos")]
     {
@@ -880,7 +897,9 @@ pub fn run() {
         ])
         .setup(|app| {
             // Resolve app data directory from Tauri
-            let app_data_dir = app.path().app_data_dir()
+            let app_data_dir = app
+                .path()
+                .app_data_dir()
                 .map_err(|e| format!("failed to resolve app data dir: {e}"))?;
 
             // Load settings from the resolved path
@@ -916,8 +935,7 @@ pub fn run() {
                 tauri::menu::MenuItem::with_id(app, "settings", "Settings...", true, None::<&str>)?;
             let show_item =
                 tauri::menu::MenuItem::with_id(app, "show_toggle", "Show", true, None::<&str>)?;
-            let quit =
-                tauri::menu::MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
+            let quit = tauri::menu::MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
             let menu = tauri::menu::Menu::with_items(app, &[&settings_item, &show_item, &quit])?;
             let show_item_ref = show_item.clone();
             let _tray = tauri::tray::TrayIconBuilder::new()
@@ -950,7 +968,10 @@ pub fn run() {
             // Check onboarding status
             let needs_onboarding = {
                 let s = app.state::<MurmurState>();
-                s.settings.lock().map(|s| !s.onboarding_complete).unwrap_or(false)
+                s.settings
+                    .lock()
+                    .map(|s| !s.onboarding_complete)
+                    .unwrap_or(false)
             };
 
             if needs_onboarding {
@@ -991,8 +1012,8 @@ pub fn run() {
             // NSWindow cannot overlay fullscreen apps regardless of level — only NSPanel can.
             #[cfg(target_os = "macos")]
             {
-                use tauri_nspanel::WebviewWindowExt;
                 use tauri_nspanel::panel::{NSWindowCollectionBehavior, NSWindowStyleMask};
+                use tauri_nspanel::WebviewWindowExt;
 
                 for name in &["main", "preview"] {
                     if let Some(w) = app.get_webview_window(name) {
@@ -1002,10 +1023,13 @@ pub fn run() {
                                 panel.set_style_mask(NSWindowStyleMask::NonactivatingPanel);
                                 panel.set_collection_behavior(
                                     NSWindowCollectionBehavior::CanJoinAllSpaces
-                                    | NSWindowCollectionBehavior::Stationary
-                                    | NSWindowCollectionBehavior::FullScreenAuxiliary,
+                                        | NSWindowCollectionBehavior::Stationary
+                                        | NSWindowCollectionBehavior::FullScreenAuxiliary,
                                 );
-                                log::info!("converted '{}' to NSPanel for fullscreen overlay", name);
+                                log::info!(
+                                    "converted '{}' to NSPanel for fullscreen overlay",
+                                    name
+                                );
                             }
                             Err(e) => {
                                 log::warn!("failed to convert '{}' to NSPanel: {}", name, e);
@@ -1031,14 +1055,16 @@ pub fn run() {
                         .unwrap_or(1.0);
                     let new_y = main_pos.y as f64 - (preview_h + gap) * scale;
                     use tauri::PhysicalPosition;
-                    let _ = preview_win.set_position(PhysicalPosition::new(main_pos.x, new_y as i32));
+                    let _ =
+                        preview_win.set_position(PhysicalPosition::new(main_pos.x, new_y as i32));
                 }
             }
 
             // Load whisper engine in background thread (non-blocking startup)
             if model_ready {
                 let app_handle = app.handle().clone();
-                let model_path = model::model_path(&app_data_dir, &model::ModelConfig::default().filename);
+                let model_path =
+                    model::model_path(&app_data_dir, &model::ModelConfig::default().filename);
                 std::thread::spawn(move || {
                     let model_path_str = match model_path.to_str() {
                         Some(s) => s.to_string(),
@@ -1103,9 +1129,7 @@ pub fn run() {
                                 "toggle" => {
                                     // Debounce: skip if last toggle was < 500ms ago
                                     if let Some(last) = last_toggle {
-                                        if last.elapsed()
-                                            < std::time::Duration::from_millis(500)
-                                        {
+                                        if last.elapsed() < std::time::Duration::from_millis(500) {
                                             continue;
                                         }
                                     }
@@ -1120,10 +1144,10 @@ pub fn run() {
                                             let _ = murmur_state
                                                 .app_state
                                                 .transition(state::RecordingState::Idle);
-                                            let _ = app_handle
-                                                .emit("recording_state_changed", "idle");
-                                            let _ = app_handle
-                                                .emit("recording_error", e.to_string());
+                                            let _ =
+                                                app_handle.emit("recording_state_changed", "idle");
+                                            let _ =
+                                                app_handle.emit("recording_error", e.to_string());
                                             hide_preview_window(&app_handle);
                                             hide_main_window(&app_handle);
                                         }
@@ -1133,10 +1157,7 @@ pub fn run() {
                                                 is_recording = true;
                                             }
                                             Err(e) => {
-                                                log::error!(
-                                                    "failed to start recording: {}",
-                                                    e
-                                                );
+                                                log::error!("failed to start recording: {}", e);
                                             }
                                         }
                                     }
@@ -1182,8 +1203,7 @@ pub fn run() {
                         }
                         hotkey::HotkeyEvent::EscCancel => {
                             let murmur_state = app_handle.state::<MurmurState>();
-                            if murmur_state.app_state.current()
-                                != state::RecordingState::Recording
+                            if murmur_state.app_state.current() != state::RecordingState::Recording
                             {
                                 continue; // Only cancel during active recording
                             }
@@ -1212,8 +1232,7 @@ pub fn run() {
 
                             // Hide windows after 2-second delay
                             let app_hide = app_handle.clone();
-                            let gen =
-                                murmur_state.preview_generation.load(Ordering::SeqCst);
+                            let gen = murmur_state.preview_generation.load(Ordering::SeqCst);
                             std::thread::spawn(move || {
                                 std::thread::sleep(std::time::Duration::from_secs(2));
                                 let ms = app_hide.state::<MurmurState>();

--- a/src-tauri/src/llm.rs
+++ b/src-tauri/src/llm.rs
@@ -555,16 +555,10 @@ mod tests {
         );
 
         // No placeholders in text
-        assert_eq!(
-            restore_english("你好世界", &placeholders),
-            "你好世界"
-        );
+        assert_eq!(restore_english("你好世界", &placeholders), "你好世界");
 
         // Empty placeholders list
-        assert_eq!(
-            restore_english("你好 __E0__", &[]),
-            "你好 __E0__"
-        );
+        assert_eq!(restore_english("你好 __E0__", &[]), "你好 __E0__");
     }
 
     #[test]
@@ -579,7 +573,10 @@ mod tests {
         assert_eq!(strip_llm_prefix("Just some text"), "Just some text");
 
         // Prefix in the middle (should not strip)
-        assert_eq!(strip_llm_prefix("Note: Output: is here"), "Note: Output: is here");
+        assert_eq!(
+            strip_llm_prefix("Note: Output: is here"),
+            "Note: Output: is here"
+        );
 
         // Multiple prefixes - should only strip one
         assert_eq!(strip_llm_prefix("Output: Cleaned: text"), "Cleaned: text");

--- a/src-tauri/src/model.rs
+++ b/src-tauri/src/model.rs
@@ -1,8 +1,8 @@
+use futures_util::StreamExt;
 use std::path::{Path, PathBuf};
 #[cfg(target_os = "windows")]
 use std::sync::Once;
 use thiserror::Error;
-use futures_util::StreamExt;
 use tokio::io::AsyncWriteExt;
 
 #[derive(Debug, Clone)]
@@ -15,7 +15,9 @@ pub struct ModelConfig {
 impl Default for ModelConfig {
     fn default() -> Self {
         Self {
-            url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin".to_string(),
+            url:
+                "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin"
+                    .to_string(),
             filename: "ggml-large-v3-turbo.bin".to_string(),
             expected_size: 1_624_555_275,
         }
@@ -77,15 +79,13 @@ fn migrate_model_from_old_path(base: &Path, filename: &str) {
         return; // already at correct location
     }
 
-    let old_path = std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .map(|h| {
-            h.join("Library")
-                .join("Application Support")
-                .join("com.murmur.voice")
-                .join("models")
-                .join(filename)
-        });
+    let old_path = std::env::var_os("HOME").map(PathBuf::from).map(|h| {
+        h.join("Library")
+            .join("Application Support")
+            .join("com.murmur.voice")
+            .join("models")
+            .join(filename)
+    });
 
     if let Some(old) = old_path {
         if old.exists() {
@@ -133,9 +133,7 @@ where
         .await
         .map_err(|e| ModelError::Download(e.to_string()))?;
 
-    let total_size = response
-        .content_length()
-        .unwrap_or(config.expected_size);
+    let total_size = response.content_length().unwrap_or(config.expected_size);
 
     let mut file = tokio::fs::File::create(&path).await?;
     let stream = response.bytes_stream();
@@ -180,7 +178,8 @@ where
         writer.write_all(data).await?;
         downloaded += data.len() as u64;
 
-        if downloaded == total_size || downloaded.saturating_sub(last_reported) >= REPORT_THRESHOLD {
+        if downloaded == total_size || downloaded.saturating_sub(last_reported) >= REPORT_THRESHOLD
+        {
             progress_callback(downloaded, total_size);
             last_reported = downloaded;
         }
@@ -222,6 +221,9 @@ mod tests {
         // 1. At 1.0MB (chunk 10) -> Call 1
         // 2. At 2.0MB (chunk 20) -> Call 2
         // 3. At 2.5MB (chunk 25/End) -> Call 3 (Total size reached)
-        assert_eq!(count, 3, "Callback should be called exactly 3 times (1MB, 2MB, End)");
+        assert_eq!(
+            count, 3,
+            "Callback should be called exactly 3 times (1MB, 2MB, End)"
+        );
     }
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -407,7 +407,7 @@ mod tests {
         };
         let t = s.ptt_key_target();
         assert_eq!(t.modifier_mask, 0x20); // NX_DEVICELALTKEYMASK
-        assert_eq!(t.regular_key, 0x06);  // CGKeyCode for Z
+        assert_eq!(t.regular_key, 0x06); // CGKeyCode for Z
     }
 
     #[test]
@@ -431,7 +431,7 @@ mod tests {
         };
         let t = s.ptt_key_target();
         assert_eq!(t.modifier_mask, 0xA4); // VK_LMENU
-        assert_eq!(t.regular_key, 0x5A);   // VK_Z
+        assert_eq!(t.regular_key, 0x5A); // VK_Z
     }
 
     #[test]
@@ -451,7 +451,10 @@ mod tests {
             dictionary: "".to_string(),
             ..Settings::default()
         };
-        assert_eq!(s.whisper_initial_prompt(), "繁體中文語音轉錄，使用台灣正體中文。");
+        assert_eq!(
+            s.whisper_initial_prompt(),
+            "繁體中文語音轉錄，使用台灣正體中文。"
+        );
     }
 
     #[test]
@@ -461,7 +464,10 @@ mod tests {
             dictionary: "".to_string(),
             ..Settings::default()
         };
-        assert_eq!(s.whisper_initial_prompt(), "繁體中文語音轉錄，使用台灣正體中文。");
+        assert_eq!(
+            s.whisper_initial_prompt(),
+            "繁體中文語音轉錄，使用台灣正體中文。"
+        );
     }
 
     #[test]
@@ -491,6 +497,9 @@ mod tests {
             dictionary: "Hello World".to_string(),
             ..Settings::default()
         };
-        assert_eq!(s.whisper_initial_prompt(), "繁體中文語音轉錄，使用台灣正體中文。 Hello World");
+        assert_eq!(
+            s.whisper_initial_prompt(),
+            "繁體中文語音轉錄，使用台灣正體中文。 Hello World"
+        );
     }
 }

--- a/src-tauri/src/whisper.rs
+++ b/src-tauri/src/whisper.rs
@@ -83,7 +83,12 @@ impl TranscriptionEngine {
         Ok(())
     }
 
-    pub(crate) fn transcribe(&self, samples: &[f32], language: &str, initial_prompt: &str) -> Result<String, WhisperError> {
+    pub(crate) fn transcribe(
+        &self,
+        samples: &[f32],
+        language: &str,
+        initial_prompt: &str,
+    ) -> Result<String, WhisperError> {
         if samples.len() < MIN_SAMPLES {
             return Ok(String::new());
         }
@@ -111,7 +116,7 @@ impl TranscriptionEngine {
         params.set_suppress_blank(true);
         params.set_no_speech_thold(0.6);
         params.set_temperature_inc(0.0); // disable temperature fallback — it just produces more hallucinations
-        params.set_entropy_thold(2.4);   // reject segments with high entropy (uncertain/hallucinated)
+        params.set_entropy_thold(2.4); // reject segments with high entropy (uncertain/hallucinated)
 
         if !initial_prompt.is_empty() {
             params.set_initial_prompt(initial_prompt);
@@ -125,11 +130,9 @@ impl TranscriptionEngine {
         let mut text = String::new();
         for i in 0..n_segments {
             if let Some(segment) = state.get_segment(i) {
-                let segment_text = segment
-                    .to_str()
-                    .map_err(|e: whisper_rs::WhisperError| {
-                        WhisperError::Transcription(e.to_string())
-                    })?;
+                let segment_text = segment.to_str().map_err(|e: whisper_rs::WhisperError| {
+                    WhisperError::Transcription(e.to_string())
+                })?;
                 text.push_str(segment_text);
             }
         }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: User's dictated voice text (whisper raw) and LLM responses (llm output) were being explicitly dumped to standard error streams using `eprintln!`.
🎯 Impact: In a production environment, terminal multiplexers, crash reporting agents, or parent processes can intercept standard error. This exposes highly sensitive personal transcription data to unintended system-level logs and monitoring tools.
🔧 Fix: Replaced `eprintln!` calls with proper `log::debug!` macros. This ensures sensitive transcription and LLM response data is stripped from the default error stream and is only logged conditionally when explicit debug configurations are enabled.
✅ Verification: Ensure standard usage no longer dumps dictation into the console running the built app unless debug flags are provided.

---
*PR created automatically by Jules for task [8220266181631887925](https://jules.google.com/task/8220266181631887925) started by @panda850819*