### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix sensitive user data leakage in standard error stream

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -425,7 +425,7 @@ fn do_stop_recording(app: &tauri::AppHandle) -> Result<String, String> {
         (llm::create_enhancer(&s), s.app_aware_style)
     };
 
-    eprintln!("[whisper raw] {}", raw_text);
+    log::debug!("[whisper raw] {}", raw_text);
 
     let text = if let Some(enhancer) = enhancer {
         if raw_text.is_empty() {
@@ -455,7 +455,7 @@ fn do_stop_recording(app: &tauri::AppHandle) -> Result<String, String> {
 
             match enhancer.enhance(&raw_text, style) {
                 Ok(processed) => {
-                    eprintln!("[llm output] {}", processed);
+                    log::debug!("[llm output] {}", processed);
                     processed
                 }
                 Err(e) => {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Raw user audio transcriptions and output generated by the LLM was inadvertently being piped to standard error using the `eprintln!` macro, which could easily bleed out to general system logs.
🎯 Impact: Potentially exposes sensitive, raw user dictations and conversations to non-secure environments and logs.
🔧 Fix: Replaced `eprintln!` calls logging the `raw_text` and `processed` data with `log::debug!`, allowing debugging outputs only when explicitly opted-in during development or deep debugging phases.
✅ Verification: Ensure the logs generated in normal or production usage no longer output `[whisper raw]` or `[llm output]` strings with transcription payloads.

---
*PR created automatically by Jules for task [13841129358790668792](https://jules.google.com/task/13841129358790668792) started by @panda850819*