### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure file creation for settings containing API keys

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Serialize};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 fn default_hold() -> String {
@@ -301,7 +304,15 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+
+    #[cfg(unix)]
+    options.mode(0o600);
+
+    let mut file = options.open(&path).map_err(|e| e.to_string())?;
+    file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
 
     #[cfg(unix)]
     std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))


### PR DESCRIPTION
🚨 **Severity:** MEDIUM

💡 **Vulnerability:** 
The application stored sensitive API keys (e.g., `groq_api_key`, `custom_llm_key`) in a `settings.json` file. The save operation previously used `std::fs::write(&path, json)` followed by `std::fs::set_permissions(..., 0o600)`. This created a Time-of-Check to Time-of-Use (TOCTOU) race condition: the file was initially created with the user's default umask permissions (often 0o644), making it potentially readable by other users on the system for a brief window before permissions were securely locked down.

🎯 **Impact:**
Any other process or user on the same system with read access to the directory could potentially read the file in the split-second before `set_permissions` executed, stealing sensitive API keys.

🔧 **Fix:**
Modified `save_settings` in `src-tauri/src/settings.rs` to use `std::fs::OpenOptions` combined with `std::os::unix::fs::OpenOptionsExt`'s `.mode(0o600)`. This guarantees the file is atomically created with strictly restricted permissions right from the start. The original explicit `set_permissions` is retained solely as a fallback to ensure any pre-existing files have their permissions corrected.

✅ **Verification:**
- Validated via standalone test verifying atomic file creation with 0600 permissions.
- Reviewed and confirmed code maintains exact same functionality for parsing, serialization, and settings operations.

---
*PR created automatically by Jules for task [6798632976169249208](https://jules.google.com/task/6798632976169249208) started by @panda850819*