### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU in settings and data leakage in logs

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -425,7 +425,7 @@ fn do_stop_recording(app: &tauri::AppHandle) -> Result<String, String> {
         (llm::create_enhancer(&s), s.app_aware_style)
     };
 
-    eprintln!("[whisper raw] {}", raw_text);
+    log::debug!("[whisper raw] {}", raw_text);
 
     let text = if let Some(enhancer) = enhancer {
         if raw_text.is_empty() {
@@ -455,7 +455,7 @@ fn do_stop_recording(app: &tauri::AppHandle) -> Result<String, String> {
 
             match enhancer.enhance(&raw_text, style) {
                 Ok(processed) => {
-                    eprintln!("[llm output] {}", processed);
+                    log::debug!("[llm output] {}", processed);
                     processed
                 }
                 Err(e) => {

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -301,11 +301,27 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
 
     #[cfg(unix)]
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| e.to_string())?;
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create(true).truncate(true).mode(0o600);
+
+        let mut file = options.open(&path).map_err(|e| e.to_string())?;
+        use std::io::Write;
+        file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
+
+        // Ensure existing files have strict permissions as well,
+        // since .mode(0o600) only applies at creation.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+            .map_err(|e| e.to_string())?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&path, json).map_err(|e| e.to_string())?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** 
1. **Time-of-Check to Time-of-Use (TOCTOU)**: `settings.json` (which contains sensitive data like API keys) was saved using `std::fs::write()`. On Unix, this creates the file with default permissions modified by the process's `umask`, and then subsequently locks permissions to `0o600` using `std::fs::set_permissions()`. This created a small window where other users on the system could potentially read the file's contents before permissions were tightened.
2. **Data Leakage**: The application unconditionally logged raw transcribed text from Whisper and LLM outputs to `stderr` using `eprintln!`. This is a significant data leakage risk, as these streams can be captured by system daemon logs, crash reporting tools, or terminal buffers, exposing sensitive user voice dictations.

🎯 **Impact:** 
- A malicious actor or process on the same machine could theoretically read the user's API keys (e.g., Groq API Key) during settings creation.
- Any tool capturing standard error could silently store the user's transcribed dictations and private text.

🔧 **Fix:** 
- Modified `save_settings` in `src-tauri/src/settings.rs` to use `std::os::unix::fs::OpenOptionsExt` with `.mode(0o600)` during the file opening process, ensuring the file is atomically created with strict permissions on Unix.
- Replaced `eprintln!` with `log::debug!` in `src-tauri/src/lib.rs` for logging Whisper raw text and LLM output, ensuring they are only visible when explicit debug logging is enabled.
- Added these critical learnings to `.jules/sentinel.md`.

✅ **Verification:** 
Verified the code logic securely uses `OpenOptions` to create the settings file and reviewed `git diff` to ensure standard error logs were removed. Code is well scoped and cleanly isolates platform specific features.

---
*PR created automatically by Jules for task [11360160954177322764](https://jules.google.com/task/11360160954177322764) started by @panda850819*