### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in settings file creation

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 
 fn default_hold() -> String {
@@ -301,11 +301,16 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
 
     #[cfg(unix)]
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| e.to_string())?;
+    options.mode(0o600);
+
+    let mut file = options.open(&path).map_err(|e| e.to_string())?;
+    use std::io::Write;
+    file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
 
     Ok(())
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Time-of-Check Time-of-Use (TOCTOU) vulnerability where the `settings.json` file (which contains sensitive API keys such as `groq_api_key`) was created with default world-readable permissions before having its permissions restricted via `set_permissions`.
🎯 Impact: A malicious local process could potentially read the file in the split second before permissions are locked down, thereby stealing the user's API key.
🔧 Fix: Replaced `std::fs::write` + `std::fs::set_permissions` with atomic file creation using `std::fs::OpenOptions` and `.mode(0o600)` via `OpenOptionsExt`.
✅ Verification: An isolated Rust test verified that files created with this new code path are immediately assigned `0o600` permissions.

---
*PR created automatically by Jules for task [16448731051618145902](https://jules.google.com/task/16448731051618145902) started by @panda850819*