### PR TITLE
⚡ Bolt: [performance improvement] Optimize audio resampling hot path

### DIFF
--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -290,13 +290,40 @@ fn resample_linear_into(input: &[f32], ratio: f64, output: &mut Vec<f32>) {
     // Optimization: Pre-calculate inverse ratio to use multiplication instead of division
     let inv_ratio = 1.0 / ratio;
 
-    for i in 0..output_len {
+    let safe_output_len = if input.len() > 1 {
+        std::cmp::min(((input.len() - 1) as f64 * ratio).floor() as usize, output_len)
+    } else {
+        0
+    };
+
+    // Optimization: Hot path with unsafe unchecked access and algebraic simplification
+    // to reduce multiplication operations from 2 to 1.
+    for i in 0..safe_output_len {
+        let src_pos = i as f64 * inv_ratio;
+        let src_idx = src_pos as usize;
+        let frac = (src_pos - src_idx as f64) as f32;
+
+        let (p1, p2) = unsafe {
+            (
+                *input.get_unchecked(src_idx),
+                *input.get_unchecked(src_idx + 1),
+            )
+        };
+        let sample = p1 + (p2 - p1) * frac;
+
+        output.push(sample);
+    }
+
+    // Optimization: Safe tail path for boundary conditions
+    for i in safe_output_len..output_len {
         let src_pos = i as f64 * inv_ratio;
         let src_idx = src_pos as usize;
         let frac = (src_pos - src_idx as f64) as f32;
 
         let sample = if src_idx + 1 < input.len() {
-            input[src_idx] * (1.0 - frac) + input[src_idx + 1] * frac
+            let p1 = input[src_idx];
+            let p2 = input[src_idx + 1];
+            p1 + (p2 - p1) * frac
         } else if src_idx < input.len() {
             input[src_idx]
         } else {


### PR DESCRIPTION
💡 What: Applied a split-loop pattern to the linear audio resampler in `src-tauri/src/audio.rs` separating bounds-checked safe tail path from an unchecked optimized hot path, and refactored the interpolation arithmetic.
🎯 Why: Audio processing happens in a tight loop and involves processing thousands of samples. Skipping bounds checking and reducing the number of multiplications inside this loop lowers CPU cycles and reduces overhead.
📊 Impact: Expected to reduce processing time overhead of audio buffer resampling.
🔬 Measurement: Verified using an isolated benchmark and `rustc -O`. Execution times dropped significantly due to omitted bounds checks and mathematical simplifications.

---
*PR created automatically by Jules for task [14633799395308115023](https://jules.google.com/task/14633799395308115023) started by @panda850819*