### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in settings file creation

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 
 fn default_hold() -> String {
@@ -301,11 +301,16 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
 
     #[cfg(unix)]
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| e.to_string())?;
+    options.mode(0o600);
+
+    let mut file = options.open(&path).map_err(|e| e.to_string())?;
+    use std::io::Write;
+    file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
 
     Ok(())
 }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A Time-of-Check to Time-of-Use (TOCTOU) vulnerability existed in `src-tauri/src/settings.rs` during settings file creation. The file was initially written with default permissions (often `0o644` or `0o666`) using `std::fs::write`, and only *afterward* were the permissions restricted to `0o600` using `std::fs::set_permissions`. This left a brief race-condition window where sensitive configuration, including the `groq_api_key`, could be read by other local users on the system.
🎯 Impact: Unauthorized local users or processes could potentially read sensitive data, such as API keys, from the settings file during the brief window before permissions were locked down.
🔧 Fix: Replaced `std::fs::write` and `std::fs::set_permissions` with `std::fs::OpenOptions` and `std::os::unix::fs::OpenOptionsExt`. By configuring `.mode(0o600)` before file creation, the file is now atomically created with restricted permissions from the very start, eliminating the race condition.
✅ Verification: Verified that the file is created with `0o600` permissions via a standalone Rust test script mapping the new logic. The code changes have also been reviewed and approved via `request_code_review`.

---
*PR created automatically by Jules for task [17625670406478459953](https://jules.google.com/task/17625670406478459953) started by @panda850819*