### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary URI scheme execution in open_url

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -711,6 +711,14 @@ async fn check_for_updates() -> Result<UpdateCheckResult, String> {
 
 #[tauri::command]
 async fn open_url(app: tauri::AppHandle, url: String) -> Result<(), String> {
+    // Security: Only allow safe URI schemes to prevent arbitrary command execution or file access
+    if !url.starts_with("http://")
+        && !url.starts_with("https://")
+        && !url.starts_with("x-apple.systempreferences:")
+    {
+        return Err("Blocked attempt to open unsafe URL scheme".to_string());
+    }
+
     use tauri_plugin_opener::OpenerExt;
     app.opener()
         .open_url(&url, None::<&str>)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `open_url` Tauri command passed unvalidated URLs from the frontend directly to `tauri_plugin_opener::OpenerExt::open_url`. This allowed potentially executing arbitrary commands or accessing local files via unsafe URI schemes (e.g., `file:///etc/passwd`, `bash://`).
🎯 Impact: An attacker exploiting an XSS vulnerability or otherwise controlling the input to the `open_url` command could execute arbitrary commands or access local files with the privileges of the Tauri application.
🔧 Fix: Implemented an allowlist for URI schemes (`http://`, `https://`, and `x-apple.systempreferences:`). URLs not matching these schemes are explicitly blocked and return an error.
✅ Verification: Created a local Rust test simulating various URLs and verified that only allowed schemes pass the check. Checked frontend usage of `open_url` to ensure valid schemas are covered.

---
*PR created automatically by Jules for task [15206156908015800647](https://jules.google.com/task/15206156908015800647) started by @panda850819*