### PR TITLE
🛡️ Sentinel: [HIGH] Fix arbitrary URI scheme execution in open_url

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -711,6 +711,15 @@ async fn check_for_updates() -> Result<UpdateCheckResult, String> {
 
 #[tauri::command]
 async fn open_url(app: tauri::AppHandle, url: String) -> Result<(), String> {
+    // SECURITY: Restrict allowed URL schemes to prevent arbitrary URI execution (e.g. file://, javascript:)
+    if !url.starts_with("http://")
+        && !url.starts_with("https://")
+        && !url.starts_with("x-apple.systempreferences:")
+    {
+        log::error!("Blocked attempt to open unauthorized URL scheme: {}", url);
+        return Err("Unauthorized URL scheme".to_string());
+    }
+
     use tauri_plugin_opener::OpenerExt;
     app.opener()
         .open_url(&url, None::<&str>)


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `open_url` Tauri command blindly passed URLs provided by the frontend directly to `tauri_plugin_opener`. This could allow arbitrary OS-level execution of dangerous schemes like `file://` to open local files, `javascript:` to potentially trigger XSS in contexts, or arbitrary local application deep links.
🎯 **Impact:** Potential access to the local filesystem or unwanted execution of installed desktop apps.
🔧 **Fix:** Added a strict prefix check to restrict execution to approved schemes: `http://`, `https://`, and `x-apple.systempreferences:`. Invalid requests are logged as errors and rejected.
✅ **Verification:** Verified that safe URLs pass and unsafe schemas (e.g. `file:///etc/passwd`) are blocked securely.

---
*PR created automatically by Jules for task [4225134513517857311](https://jules.google.com/task/4225134513517857311) started by @panda850819*