### PR TITLE
🛡️ Sentinel: [HIGH] Fix sensitive data leakage via stdout/stderr

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -572,7 +572,7 @@ fn do_stop_recording(app: &tauri::AppHandle) -> Result<String, String> {
         (llm::create_enhancer(&s), s.app_aware_style)
     };
 
-    eprintln!("[whisper raw] {}", raw_text);
+    log::debug!("[whisper raw] {}", raw_text);
 
     let text = if let Some(enhancer) = enhancer {
         if raw_text.is_empty() {
@@ -602,7 +602,7 @@ fn do_stop_recording(app: &tauri::AppHandle) -> Result<String, String> {
 
             match enhancer.enhance(&raw_text, style) {
                 Ok(processed) => {
-                    eprintln!("[llm output] {}", processed);
+                    log::debug!("[llm output] {}", processed);
                     processed
                 }
                 Err(e) => {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The application was logging raw user microphone transcriptions and LLM text output directly to standard error using `eprintln!`.
🎯 **Impact:** In production environments, standard error is often captured by system logs (e.g., `journald`), crash reporters, log management tools, or terminal histories. This means highly sensitive data—like private conversations, passwords spoken out loud, or confidential notes—could easily leak to unintended locations or third parties monitoring the system.
🔧 **Fix:** Replaced the hardcoded `eprintln!` statements in `do_stop_recording` (`src-tauri/src/lib.rs`) with `log::debug!`. This ensures diagnostic data is properly leveled and can be silenced in production builds by configuring the `log` crate, complying with data privacy best practices.
✅ **Verification:** Ran `grep -rn "eprintln" src-tauri/src/` to confirm no other instances exist and triggered `cargo test` (with failures constrained to missing VM system packages, unrelated to the code change).

Additionally, logged this vulnerability pattern in `.jules/sentinel.md` as instructed to prevent regressions.

---
*PR created automatically by Jules for task [13180036009592432880](https://jules.google.com/task/13180036009592432880) started by @panda850819*