### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in settings file creation

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,6 +1,4 @@
 use serde::{Deserialize, Serialize};
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
 fn default_hold() -> String {
@@ -323,11 +321,19 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
 
     #[cfg(unix)]
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| e.to_string())?;
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+
+    let mut file = options.open(&path).map_err(|e| e.to_string())?;
+    use std::io::Write;
+    file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
 
     Ok(())
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `save_settings` function in `src-tauri/src/settings.rs` wrote configuration data (including sensitive API keys) to the `settings.json` file using `std::fs::write`. This function creates files with system-default permissions (potentially world-readable). It then subsequently called `std::fs::set_permissions` to lock the permissions down to `0o600`. This created a brief Time-of-Check to Time-of-Use (TOCTOU) race condition during which an attacker on the same machine could access the API keys.
🎯 Impact: Local privilege escalation/information disclosure. Another process could read the file in the split second before permissions are tightened.
🔧 Fix: Used `std::fs::OpenOptions` in conjunction with `std::os::unix::fs::OpenOptionsExt`'s `.mode(0o600)` to atomically create the file with restricted permissions.
✅ Verification: Tested isolated creation of files with the new logic verifying they are created as `-rw-------` correctly and securely.

---
*PR created automatically by Jules for task [9381800149526254238](https://jules.google.com/task/9381800149526254238) started by @panda850819*