### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in configuration file creation

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::OpenOptionsExt;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 fn default_hold() -> String {
@@ -323,11 +324,15 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
 
     #[cfg(unix)]
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| e.to_string())?;
+    options.mode(0o600);
+
+    let mut file = options.open(&path).map_err(|e| e.to_string())?;
+    file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
 
     Ok(())
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** A Time-of-Check to Time-of-Use (TOCTOU) vulnerability in `save_settings`. The settings file was previously created with `std::fs::write` (using default permissions) and then subsequently restricted via `std::fs::set_permissions(0o600)`.
🎯 **Impact:** Because the application stores sensitive information such as `groq_api_key` in the settings file, there was a brief window where another user on the system could potentially read or modify the file before its permissions were secured.
🔧 **Fix:** Changed the file writing logic to use `std::fs::OpenOptions` with `std::os::unix::fs::OpenOptionsExt`. By calling `options.mode(0o600)` prior to opening the file, it guarantees the file is securely created with restricted permissions from the start.
✅ **Verification:** Verified that `OpenOptionsExt` is imported and used correctly on Unix platforms. Also cleaned up development test scratchpads.

---
*PR created automatically by Jules for task [6495537871886612519](https://jules.google.com/task/6495537871886612519) started by @panda850819*