### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure file creation permissions

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,6 +1,4 @@
 use serde::{Deserialize, Serialize};
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
 fn default_hold() -> String {
@@ -323,11 +321,19 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
 
     #[cfg(unix)]
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| e.to_string())?;
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+
+    use std::io::Write;
+    let mut file = options.open(&path).map_err(|e| e.to_string())?;
+    file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
 
     Ok(())
 }


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Time-of-Check to Time-of-Use (TOCTOU) vulnerability when saving application settings in `src-tauri/src/settings.rs`. The code was writing the settings file (which contains sensitive data like API keys) with default permissions and subsequently setting restricted permissions (0o600) using `std::fs::set_permissions`. This introduced a temporary window where the file was accessible with broader permissions.
🎯 **Impact:** A local malicious user or process could potentially read sensitive data, like API keys, from the settings file during the small window before the restricted permissions were applied.
🔧 **Fix:** Utilized `std::fs::OpenOptions` combined with `std::os::unix::fs::OpenOptionsExt` to set the file permissions (`options.mode(0o600)`) directly upon file creation. This ensures that the file is created atomically with the correct restricted permissions, eliminating the vulnerable window.
✅ **Verification:** Verified that tests pass and the file creation correctly enforces the specified mode locally via a standalone script since system dependencies limit `cargo test` in the current environment.

---
*PR created automatically by Jules for task [15963882273024468258](https://jules.google.com/task/15963882273024468258) started by @panda850819*