### PR TITLE
🛡️ Sentinel: [security improvement] replace innerHTML with textContent

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -216,7 +216,8 @@ function showStatus(message, isError) {
 
 function renderDictTags() {
   const container = el("dict-tags");
-  container.innerHTML = "";
+  // Security: Avoid innerHTML to prevent XSS sinks
+  container.textContent = "";
   dictTags.forEach((term, i) => {
     const tag = document.createElement("span");
     tag.className = "dict-tag";


### PR DESCRIPTION
🛡️ Sentinel: [security improvement] replace innerHTML with textContent

🚨 Severity: LOW
💡 Vulnerability: Use of `.innerHTML` to clear a DOM element is often flagged as an XSS sink by SAST tools, even when assigning an empty string.
🎯 Impact: While an empty string assignment cannot execute malicious payload, eliminating `innerHTML` prevents future accidental misuse and satisfies strict static analysis.
🔧 Fix: Replaced `container.innerHTML = ""` with `container.textContent = ""` which is safer and achieves the same functional result.
✅ Verification: Ran a temporary JSdom script to confirm `textContent = ""` correctly removes child nodes, and generated a UI screenshot to ensure `renderDictTags` still correctly populates and clears the `dictTags` display.

---
*PR created automatically by Jules for task [10920032503114154026](https://jules.google.com/task/10920032503114154026) started by @panda850819*