### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix API Key Plaintext Vulnerability

### DIFF
--- a/src/onboarding.css
+++ b/src/onboarding.css
@@ -241,7 +241,8 @@ h1 {
   width: 100%;
 }
 
-.groq-key-wrap input {
+.groq-key-wrap input[type="text"],
+.groq-key-wrap input[type="password"] {
   width: 100%;
   padding: 8px 12px;
   font-family: inherit;
@@ -254,12 +255,14 @@ h1 {
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
-.groq-key-wrap input:focus {
+.groq-key-wrap input[type="text"]:focus,
+.groq-key-wrap input[type="password"]:focus {
   border-color: var(--accent);
   box-shadow: 0 0 0 2px var(--accent-glow);
 }
 
-.groq-key-wrap input::placeholder {
+.groq-key-wrap input[type="text"]::placeholder,
+.groq-key-wrap input[type="password"]::placeholder {
   color: var(--text-muted);
 }
 

--- a/src/onboarding.html
+++ b/src/onboarding.html
@@ -114,7 +114,7 @@
           </button>
         </div>
         <div id="groq-key-wrap" class="groq-key-wrap hidden">
-          <input id="onboard-groq-key" type="text" data-i18n="onboard.apiKeyPlaceholder" placeholder="Groq API Key (gsk_...)" />
+          <input id="onboard-groq-key" type="password" data-i18n="onboard.apiKeyPlaceholder" placeholder="Groq API Key (gsk_...)" />
         </div>
         <div class="step-actions">
           <button class="btn ghost back-btn" data-back="2" data-i18n="onboard.back">Back</button>


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The Groq API Key input field in the onboarding process was set to `type="text"`.
🎯 **Impact:** Exposes the user's permanent API key in plaintext, leading to potential credential theft via shoulder surfing, screen sharing, or OS-level input capture.
🔧 **Fix:** Changed the input type from `text` to `password` and updated the corresponding CSS class to target the modified element so that styling is preserved.
✅ **Verification:** Verified via Playwright that the API Key field is successfully obscured and appropriately styled.

---
*PR created automatically by Jules for task [12891509084336009245](https://jules.google.com/task/12891509084336009245) started by @panda850819*