### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix data leakage in logging

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -572,7 +572,7 @@ fn do_stop_recording(app: &tauri::AppHandle) -> Result<String, String> {
         (llm::create_enhancer(&s), s.app_aware_style)
     };
 
-    eprintln!("[whisper raw] {}", raw_text);
+    log::debug!("[whisper raw] {}", raw_text);
 
     let text = if let Some(enhancer) = enhancer {
         if raw_text.is_empty() {
@@ -602,7 +602,7 @@ fn do_stop_recording(app: &tauri::AppHandle) -> Result<String, String> {
 
             match enhancer.enhance(&raw_text, style) {
                 Ok(processed) => {
-                    eprintln!("[llm output] {}", processed);
+                    log::debug!("[llm output] {}", processed);
                     processed
                 }
                 Err(e) => {


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: Sensitive user text (raw audio transcriptions from Whisper and post-processed outputs from the LLM) were being logged directly to standard error using `eprintln!`.
🎯 **Impact**: Any process, system service, or user with access to the application's standard error stream could view private and potentially sensitive user data (PII).
🔧 **Fix**: Replaced all instances of `eprintln!` with `log::debug!` in `src-tauri/src/lib.rs`. This ensures that sensitive data is only logged when the application is explicitly run with debug logging enabled, protecting user privacy in standard production runs. Also documented this critical finding in `.jules/sentinel.md`.
✅ **Verification**: Code compiles successfully and standard error streams will no longer output user transcripts.

---
*PR created automatically by Jules for task [6692136557786011486](https://jules.google.com/task/6692136557786011486) started by @panda850819*