### PR TITLE
⚡ Bolt: [performance improvement] Optimize audio resampling loop

### DIFF
--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -291,7 +291,30 @@ fn resample_linear_into(input: &[f32], ratio: f64, output: &mut Vec<f32>) {
     // Optimization: Pre-calculate inverse ratio to use multiplication instead of division
     let inv_ratio = 1.0 / ratio;
 
-    for i in 0..output_len {
+    // Split loop optimization:
+    // Calculate the safe output length where `src_idx + 1 < input.len()` is guaranteed to be true.
+    let safe_output_len = if input.len() > 1 {
+        std::cmp::min(output_len, ((input.len() - 1) as f64 * ratio).floor() as usize)
+    } else {
+        0
+    };
+
+    // Hot loop: bounds checking eliminated
+    for i in 0..safe_output_len {
+        let src_pos = i as f64 * inv_ratio;
+        let src_idx = src_pos as usize;
+        let frac = (src_pos - src_idx as f64) as f32;
+
+        let sample = unsafe {
+            // SAFETY: src_idx is guaranteed to be < input.len() - 1 because i < safe_output_len
+            *input.get_unchecked(src_idx) * (1.0 - frac) + *input.get_unchecked(src_idx + 1) * frac
+        };
+
+        output.push(sample);
+    }
+
+    // Tail loop for boundary elements
+    for i in safe_output_len..output_len {
         let src_pos = i as f64 * inv_ratio;
         let src_idx = src_pos as usize;
         let frac = (src_pos - src_idx as f64) as f32;


### PR DESCRIPTION
💡 **What**: Refactored `resample_linear_into` in `src-tauri/src/audio.rs` to use split-loop optimization with an `unsafe` hot-path.
🎯 **Why**: Audio resampling occurs directly within the high-frequency cpal input callback. Eliminating redundant bounds checking for every interpolated frame during array traversal reduces CPU cycles and assists with auto-vectorization, preventing audio dropping or callback starvation.
📊 **Impact**: Expected to reduce CPU overhead in the cpal input thread, improving resilience during high-load recording sessions, especially on lower-end devices processing 16kHz audio up-sampling or down-sampling.
🔬 **Measurement**: Verified the logic maintains mathematical correctness by running test equivalents and evaluating bounds conditions. Safety comments document the exact boundaries that guarantee memory safety without relying on the CPU bounds checker.

---
*PR created automatically by Jules for task [9959958333084260302](https://jules.google.com/task/9959958333084260302) started by @panda850819*