### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix plaintext API key input in onboarding

### DIFF
--- a/src/onboarding.html
+++ b/src/onboarding.html
@@ -114,7 +114,7 @@
           </button>
         </div>
         <div id="groq-key-wrap" class="groq-key-wrap hidden">
-          <input id="onboard-groq-key" type="text" data-i18n="onboard.apiKeyPlaceholder" placeholder="Groq API Key (gsk_...)" />
+          <input id="onboard-groq-key" type="password" data-i18n="onboard.apiKeyPlaceholder" placeholder="Groq API Key (gsk_...)" />
         </div>
         <div class="step-actions">
           <button class="btn ghost back-btn" data-back="2" data-i18n="onboard.back">Back</button>


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `onboard-groq-key` input field was set to `type="text"`, meaning the user's Groq API key was visible in plaintext while typing or when the settings window was open.
🎯 **Impact:** Exposes a sensitive, long-lived secret (Groq API key) to screen sharing, shoulder surfing, and accidental screenshots, violating the principle of securing sensitive credentials.
🔧 **Fix:** Changed `<input type="text">` to `<input type="password">` in `src/onboarding.html` so the input is masked with dots.
✅ **Verification:** Verified visually via Playwright that when typing into the Groq API Key field in the onboarding flow, the text is properly masked as a password.

---
*PR created automatically by Jules for task [9181580009839963806](https://jules.google.com/task/9181580009839963806) started by @panda850819*