### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix exposed API key in plaintext during onboarding

### DIFF
--- a/src/onboarding.html
+++ b/src/onboarding.html
@@ -114,7 +114,7 @@
           </button>
         </div>
         <div id="groq-key-wrap" class="groq-key-wrap hidden">
-          <input id="onboard-groq-key" type="text" data-i18n="onboard.apiKeyPlaceholder" placeholder="Groq API Key (gsk_...)" />
+          <input id="onboard-groq-key" type="password" data-i18n="onboard.apiKeyPlaceholder" placeholder="Groq API Key (gsk_...)" />
         </div>
         <div class="step-actions">
           <button class="btn ghost back-btn" data-back="2" data-i18n="onboard.back">Back</button>


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The Groq API key was rendered in plaintext during the onboarding flow because the input field used `type="text"`.
🎯 Impact: Anyone looking at the user's screen during onboarding could easily see and compromise their long-lived API key, leading to unauthorized use of their Groq account.
🔧 Fix: Changed the input type to `password` in `src/onboarding.html` to obscure the characters.
✅ Verification: Tested via Playwright to confirm the dots render successfully, hiding the text. No test regressions observed.

---
*PR created automatically by Jules for task [14358855569824599462](https://jules.google.com/task/14358855569824599462) started by @panda850819*