### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in settings file creation

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
+use std::io::Write;
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 
 
@@ -340,11 +341,16 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
+
+    // Secure configuration data and prevent TOCTOU vulnerabilities
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
 
     #[cfg(unix)]
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| e.to_string())?;
+    options.mode(0o600);
+
+    let mut file = options.open(&path).map_err(|e| e.to_string())?;
+    file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
 
     Ok(())
 }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Identified a Time-of-Check to Time-of-Use (TOCTOU) race condition in how the settings configuration file was saved. Previously, the file was written, and then its permissions were restricted to `0o600`. This left a brief window where the file existed with broader default permissions, potentially exposing sensitive configuration data (such as API keys).
🎯 **Impact:** An attacker or another unauthorized process could potentially read the sensitive configuration data during the brief window before permissions were restricted.
🔧 **Fix:** Refactored the `save_settings` function in `src-tauri/src/settings.rs` to use `std::fs::OpenOptions` combined with the Unix-specific `OpenOptionsExt::mode`. This approach atomically instructs the OS to create the file with the `0o600` permissions from the start, closing the TOCTOU window.
✅ **Verification:**
1. Code review confirms the use of `OpenOptions` and `mode(0o600)` replaces `fs::write` and `fs::set_permissions`.
2. Manual verification in the Linux environment shows correct code logic without regressions.
3. Relevant learning has been securely documented in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [4546084619252593692](https://jules.google.com/task/4546084619252593692) started by @panda850819*