### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in settings file creation

### DIFF
--- a/src-tauri/src/hotkey_windows.rs
+++ b/src-tauri/src/hotkey_windows.rs
@@ -67,6 +67,7 @@ pub(crate) fn pause_hotkey(mode: RecordingMode) {
 }
 
 /// Disable all hotkey slots.
+#[allow(dead_code)]
 pub(crate) fn pause_all_hotkeys() {
     for slot in &HOTKEY_SLOTS {
         slot.modifier_mask.store(0, Ordering::SeqCst);

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
+use std::fs::OpenOptions;
+use std::io::Write;
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 
 fn default_true() -> bool {
@@ -175,6 +177,11 @@ fn combine_modifier_masks(modifiers: &[&str]) -> u64 {
         modifiers.iter().enumerate().fold(0u64, |acc, (i, &m)| {
             acc | (modifier_mask_for(m) << (i * 16))
         })
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        let _ = modifiers;
+        0
     }
 }
 
@@ -430,11 +437,15 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
+
+    let mut options = OpenOptions::new();
+    options.write(true).create(true).truncate(true);
 
     #[cfg(unix)]
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| e.to_string())?;
+    options.mode(0o600);
+
+    let mut file = options.open(&path).map_err(|e| e.to_string())?;
+    file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
 
     Ok(())
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** A Time-of-Check to Time-of-Use (TOCTOU) vulnerability existed in `src-tauri/src/settings.rs`. The application settings file, which contains sensitive user information like custom API keys, was created using `std::fs::write` (which applies default system permissions like `0o644`) before a subsequent call to `std::fs::set_permissions` attempted to secure it to `0o600`.
🎯 **Impact:** This created a brief race condition window during which any unauthorized user on the local system could read the newly created file and potentially steal sensitive API keys before the permissions were successfully restricted.
🔧 **Fix:** Replaced the vulnerable `std::fs::write` and `set_permissions` calls with an atomic implementation using `std::fs::OpenOptions` and `std::os::unix::fs::OpenOptionsExt::mode(0o600)`. The file is now guaranteed to be created with secure permissions right from the start. I also resolved a minor compilation lint issue in `combine_modifier_masks` for non-supported targets.
✅ **Verification:** A standalone test verified the files are now atomically created with strict `-rw-------` (0600) permissions. Backend compilation works and tests pass on supported systems.

---
*PR created automatically by Jules for task [11822764981594222486](https://jules.google.com/task/11822764981594222486) started by @panda850819*