### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in settings file creation

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 
 fn default_true() -> bool {
@@ -175,6 +175,11 @@ fn combine_modifier_masks(modifiers: &[&str]) -> u64 {
         modifiers.iter().enumerate().fold(0u64, |acc, (i, &m)| {
             acc | (modifier_mask_for(m) << (i * 16))
         })
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        let _ = modifiers;
+        0
     }
 }
 
@@ -425,16 +430,22 @@ pub(crate) fn load_settings(base: &Path) -> Settings {
 }
 
 pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), String> {
+    use std::io::Write;
+
     let path = settings_path(base);
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
 
     #[cfg(unix)]
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| e.to_string())?;
+    options.mode(0o600);
+
+    let mut file = options.open(&path).map_err(|e| e.to_string())?;
+    file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
 
     Ok(())
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Time-of-Check to Time-of-Use (TOCTOU) vulnerability during settings file creation. The configuration file was being created with default permissions (potentially world-readable) before being locked down to `0o600`.
🎯 **Impact:** Sensitive configuration data, including the `groq_api_key` and other LLM tokens, could momentarily be read by other users on the system during the split second between file creation and permission restriction.
🔧 **Fix:** Replaced the non-atomic `std::fs::write` and `std::fs::set_permissions` sequence with `std::fs::OpenOptions`. Using `std::os::unix::fs::OpenOptionsExt`, the file is now atomically created with the strict `.mode(0o600)` permissions, preventing any window of exposure.
✅ **Verification:** Verified by checking code paths using `cargo clippy` and `cargo test`, and confirming that `std::fs::OpenOptionsExt::mode` correctly applies on Unix targets during creation.

---
*PR created automatically by Jules for task [3429478553886379557](https://jules.google.com/task/3429478553886379557) started by @panda850819*