### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in configuration file creation

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
+use std::io::Write;
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 
 fn default_true() -> bool {
@@ -175,6 +176,11 @@ fn combine_modifier_masks(modifiers: &[&str]) -> u64 {
         modifiers.iter().enumerate().fold(0u64, |acc, (i, &m)| {
             acc | (modifier_mask_for(m) << (i * 16))
         })
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        let _ = modifiers;
+        0
     }
 }
 
@@ -430,11 +436,15 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
 
     #[cfg(unix)]
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| e.to_string())?;
+    options.mode(0o600);
+
+    let mut file = options.open(&path).map_err(|e| e.to_string())?;
+    file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
 
     Ok(())
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Time-of-Check, Time-of-Use (TOCTOU) / race condition in configuration file creation. The configuration file was being created with default permissions using `std::fs::write`, and then subsequently restricted using `std::fs::set_permissions`. This left a brief window where another process could read the sensitive file contents.
🎯 Impact: An attacker or unauthorized process could read the settings file before permissions were restricted, potentially gaining access to sensitive application data or API keys stored within it.
🔧 Fix: Used `std::fs::OpenOptions` combined with `.mode(0o600)` on Unix platforms to guarantee atomic creation of the file with secure owner-only read/write permissions from the moment it is written to the filesystem.
✅ Verification: Ensure the Rust code compiles correctly without errors via `cargo check`. Evaluated the `save_settings` logic to confirm it correctly applies atomic file operations. Added a critical learning to `.jules/sentinel.md` regarding atomic permission configuration.

---
*PR created automatically by Jules for task [3565877099973060658](https://jules.google.com/task/3565877099973060658) started by @panda850819*