### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix TOCTOU vulnerability in settings file creation

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,6 +1,4 @@
 use serde::{Deserialize, Serialize};
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
 fn default_true() -> bool {

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -430,11 +430,24 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
 
     #[cfg(unix)]
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| e.to_string())?;
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&path)
+            .map_err(|e| e.to_string())?;
+        file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&path, json).map_err(|e| e.to_string())?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** A Time-of-Check to Time-of-Use (TOCTOU) vulnerability existed in `save_settings` where settings files were written with `std::fs::write` (which creates the file with default permissions) and then locked down using `std::fs::set_permissions`.
🎯 **Impact:** This left a brief window where potentially sensitive configuration could be read by other local users on the system.
🔧 **Fix:** Replaced the two-step process with `std::fs::OpenOptions` and `std::os::unix::fs::OpenOptionsExt::mode(0o600)` to ensure strict permissions are set atomically during file creation on Unix systems. Added a fallback for non-unix systems using the standard `std::fs::write`.
✅ **Verification:** Verified that standalone file writing script generates file with `100600` permissions. Backend `settings` unit tests successfully pass locally.

---
*PR created automatically by Jules for task [18156872262313324884](https://jules.google.com/task/18156872262313324884) started by @panda850819*