### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix TOCTOU vulnerability in file creation

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
+use std::io::Write;
 
 fn default_true() -> bool {
     true
@@ -430,11 +431,15 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
 
     #[cfg(unix)]
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| e.to_string())?;
+    options.mode(0o600);
+
+    let mut file = options.open(&path).map_err(|e| e.to_string())?;
+    file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
 
     Ok(())
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Time-Of-Check to Time-Of-Use (TOCTOU) race condition in `save_settings`.
🎯 Impact: The settings file was previously created with default permissions and subsequently restricted, creating a small window where sensitive data (like API keys) could be read by unauthorized local users.
🔧 Fix: Updated `save_settings` to use `std::fs::OpenOptions` combined with `.mode(0o600)` on Unix to ensure the file is created atomically with restricted permissions natively.
✅ Verification: Tested isolated file creation logic on Unix and verified the created file has exactly `0o600` permissions upon creation.

---
*PR created automatically by Jules for task [14059599330155285792](https://jules.google.com/task/14059599330155285792) started by @panda850819*