### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix TOCTOU vulnerability in file permissions

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,6 +1,4 @@
 use serde::{Deserialize, Serialize};
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
 fn default_true() -> bool {

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -430,11 +430,27 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
 
+    // SECURITY: Use OpenOptions with mode(0o600) to create and write the file
+    // atomically, preventing a Time-Of-Check to Time-Of-Use (TOCTOU) vulnerability.
     #[cfg(unix)]
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| e.to_string())?;
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&path)
+            .map_err(|e| e.to_string())?;
+        use std::io::Write;
+        file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&path, json).map_err(|e| e.to_string())?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Time-Of-Check to Time-Of-Use (TOCTOU) vulnerability during settings file saving. The `save_settings` function previously wrote the settings file (which contains API keys) with default permissions and then subsequently called `set_permissions` to restrict it to `0o600`. This left a brief window where another local process could read the file before it was secured.
🎯 **Impact:** If exploited, a malicious local process could potentially read sensitive configuration data such as API keys from the settings file during the race condition window.
🔧 **Fix:** Modified `save_settings` to use `std::fs::OpenOptions` with `.mode(0o600)` (via `std::os::unix::fs::OpenOptionsExt`) on Unix systems to create and write the file atomically with restricted permissions, closing the TOCTOU window.
✅ **Verification:** Verified by code inspection and isolated logic execution. The file is successfully written with `600` permissions upon creation.

---
*PR created automatically by Jules for task [17126765929031976759](https://jules.google.com/task/17126765929031976759) started by @panda850819*