### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix TOCTOU vulnerability in settings file creation

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -430,11 +430,25 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
 
     #[cfg(unix)]
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| e.to_string())?;
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600) // Avoid TOCTOU: create securely directly
+            .open(&path)
+            .map_err(|e| e.to_string())?;
+        file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&path, json).map_err(|e| e.to_string())?;
+    }
 
     Ok(())
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,6 +1,4 @@
 use serde::{Deserialize, Serialize};
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
 fn default_true() -> bool {


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** TOCTOU (Time-of-Check to Time-of-Use) file creation race condition in `save_settings`.
🎯 **Impact:** When settings (which contain sensitive API keys like `groq_api_key` and `custom_llm_key`) are saved, the file is briefly created with default open permissions before being restricted to `0o600`. A concurrent local process could read the file during this microsecond window and exfiltrate keys.
🔧 **Fix:** Changed file writing from `std::fs::write` + `set_permissions` to an atomic creation using `std::fs::OpenOptions` with `.mode(0o600)` via `std::os::unix::fs::OpenOptionsExt` to guarantee secure permissions from the moment the file handle is created. 
✅ **Verification:**
1. Code review of `src-tauri/src/settings.rs` confirms atomic `.mode(0o600)` usage.
2. Ran `cargo test` and `cargo clippy --all-targets -- -D warnings`.

---
*PR created automatically by Jules for task [14850633987199740765](https://jules.google.com/task/14850633987199740765) started by @panda850819*