### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -425,16 +425,25 @@ pub(crate) fn load_settings(base: &Path) -> Settings {
 }
 
 pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), String> {
+    use std::io::Write;
     let path = settings_path(base);
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
+
+    // Fix: Prevent TOCTOU vulnerability by using OpenOptions to atomically create the file with restricted permissions.
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
 
     #[cfg(unix)]
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| e.to_string())?;
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+
+    let mut file = options.open(&path).map_err(|e| e.to_string())?;
+    file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
 
     Ok(())
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,6 +1,4 @@
 use serde::{Deserialize, Serialize};
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
 fn default_true() -> bool {


### PR DESCRIPTION
🚨 Severity: LOW
💡 Vulnerability: A Time-of-Check to Time-of-Use (TOCTOU) vulnerability where `settings.json` (which contains sensitive data like API keys) is briefly written with default readable permissions before having its permissions restricted via `set_permissions(0o600)`.
🎯 Impact: Another process could theoretically read the contents of `settings.json` between the write and the permission change. Though the impact is considered low in this desktop app context, it's poor security practice to store sensitive data briefly with relaxed permissions.
🔧 Fix: Replaced `std::fs::write` with `std::fs::OpenOptions` and `std::os::unix::fs::OpenOptionsExt`'s `.mode(0o600)` to ensure atomic file creation with restricted permissions from the start.
✅ Verification: Ran `cargo clippy` and ran a standalone rust script verifying the fix logic works.

---
*PR created automatically by Jules for task [9702732811017818112](https://jules.google.com/task/9702732811017818112) started by @panda850819*