### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in settings file creation

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 #[cfg(unix)]
-use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 
 fn default_true() -> bool {

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 
 fn default_true() -> bool {
@@ -430,11 +430,17 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
 
     #[cfg(unix)]
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| e.to_string())?;
+    options.mode(0o600);
+
+    let mut file = options.open(&path).map_err(|e| e.to_string())?;
+
+    use std::io::Write;
+    file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
 
     Ok(())
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** A TOCTOU (Time-Of-Check to Time-Of-Use) vulnerability existed in `src-tauri/src/settings.rs` during settings file creation. `std::fs::write` creates files with default permissions (often 0644 depending on umask), and subsequently restricted access using `set_permissions` to `0o600`. This left a brief window where sensitive settings, such as `groq_api_key`, were readable by other system users.
🎯 **Impact:** Malicious actors or other users on the system could theoretically read sensitive API keys during the window between file creation and permission restriction, leading to potential unauthorized access or API usage.
🔧 **Fix:** Refactored `save_settings` to use `std::fs::OpenOptions` combined with Unix-specific `.mode(0o600)` extension. This ensures the configuration file is atomically created with restricted permissions from the start.
✅ **Verification:** Verified compilation natively and via code review. The fix employs idiomatic and secure Rust filesystem operations using standard library extensions.

---
*PR created automatically by Jules for task [17327966977015087140](https://jules.google.com/task/17327966977015087140) started by @panda850819*