### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
+use std::io::Write;
 
 fn default_true() -> bool {
     true
@@ -430,11 +431,15 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
 
     #[cfg(unix)]
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| e.to_string())?;
+    options.mode(0o600);
+
+    let mut file = options.open(&path).map_err(|e| e.to_string())?;
+    file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
 
     Ok(())
 }


### PR DESCRIPTION
🚨 **Severity:** LOW

💡 **Vulnerability:** The application previously created the `settings.json` file using `std::fs::write` and then modified its permissions to `0o600` on Unix systems. This created a Time-of-Check to Time-of-Use (TOCTOU) vulnerability where the sensitive file (containing API keys) was briefly created with default system permissions, allowing a tiny window for other local users to read it.

🎯 **Impact:** If exploited, a local malicious user could potentially read the file during the fraction of a second before the permissions were locked down, exposing saved API keys. Because this is a desktop app and requires local access, the severity is LOW, but this defense-in-depth fix removes the race condition.

🔧 **Fix:** Replaced `std::fs::write` with `std::fs::OpenOptions`. On Unix systems, `std::os::unix::fs::OpenOptionsExt` is imported to apply `.mode(0o600)` directly to the file options before it is created. This ensures the file is initialized with the correct restricted permissions atomically.

✅ **Verification:** Verified by compiling the Rust backend. A standalone Rust script mimicking the exact `OpenOptions` logic was also created to assert that the file is correctly created with `0600` permissions.

---
*PR created automatically by Jules for task [11029396095184114679](https://jules.google.com/task/11029396095184114679) started by @panda850819*