### PR TITLE
🛡️ Sentinel: [security improvement] Prevent TOCTOU on settings file creation

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 
 fn default_true() -> bool {
@@ -430,11 +430,28 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
 
+    // Security: Prevent TOCTOU vulnerability on Unix by creating the file atomically
+    // with restricted permissions (0o600) rather than writing and changing permissions later.
     #[cfg(unix)]
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| e.to_string())?;
+    {
+        use std::io::Write;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&path)
+            .map_err(|e| e.to_string())?;
+        file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
+
+        // Healing: Ensure existing files with wider permissions are restricted
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+            .map_err(|e| e.to_string())?;
+    }
+
+    #[cfg(not(unix))]
+    std::fs::write(&path, json).map_err(|e| e.to_string())?;
 
     Ok(())
 }


### PR DESCRIPTION
🛡️ Sentinel: [security improvement]

🚨 **Severity:** LOW (Local desktop app)
💡 **Vulnerability:** The application was creating a sensitive `settings.json` file using `std::fs::write` and subsequently restricting its permissions using `std::fs::set_permissions`. This introduces a Time-of-Check to Time-of-Use (TOCTOU) vulnerability where an attacker could read the file in the small window between creation and permission modification.
🎯 **Impact:** Potential leakage of API keys (like Groq API key) on Unix systems to other users on the machine during the split-second write window.
🔧 **Fix:** On Unix systems, modified `save_settings` to use `std::fs::OpenOptions` with `std::os::unix::fs::OpenOptionsExt`'s `.mode(0o600)` to ensure the file is created atomically with restricted permissions. Kept the subsequent `set_permissions` call to "heal" existing files that might already have wider permissions.
✅ **Verification:** Compiled and ran isolated standalone Rust scripts locally mimicking the logic to ensure that file creation and permission restriction worked correctly on the Unix platform.

---
*PR created automatically by Jules for task [16439563095990461666](https://jules.google.com/task/16439563095990461666) started by @panda850819*