### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix TOCTOU vulnerability in settings file creation

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -430,11 +430,29 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
 
     #[cfg(unix)]
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| e.to_string())?;
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&path)
+            .map_err(|e| e.to_string())?;
+        file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
+
+        // Heal existing files if they were created with wider permissions previously
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+            .map_err(|e| e.to_string())?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&path, json).map_err(|e| e.to_string())?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: A Time-of-Check to Time-of-Use (TOCTOU) file permission race condition existed when saving `settings.json`. The file was initially created using `std::fs::write` (applying default permissions) and then its permissions were explicitly restricted to `0o600`.
🎯 Impact: This left a brief execution window where sensitive configuration data (such as API keys) could potentially be read by an unauthorized local actor on Unix systems before the permissions were locked down.
🔧 Fix: Updated `save_settings` to use `std::fs::OpenOptions` with `std::os::unix::fs::OpenOptionsExt`'s `.mode(0o600)`. This guarantees the file is securely and atomically created with strict permissions from the start. A fallback `set_permissions` call remains to 'heal' any existing settings files that might have been created with wider permissions in previous versions.
✅ Verification: Tested isolated file creation logic on a Unix environment to ensure the file is created with correct `rw-------` permissions on disk. Passed code review. Documented learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [16224360268208745997](https://jules.google.com/task/16224360268208745997) started by @panda850819*