### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -430,11 +430,28 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
 
     #[cfg(unix)]
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| e.to_string())?;
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&path)
+            .map_err(|e| e.to_string())?;
+        file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
+
+        // Truncate preserves existing permissions, so we also heal them here
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+            .map_err(|e| e.to_string())?;
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&path, json).map_err(|e| e.to_string())?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
🚨 Severity: LOW (Local desktop app; requires local access)
💡 Vulnerability: `std::fs::write` creates files with default wide permissions (e.g. 0o644 based on umask) before the subsequent `std::fs::set_permissions(0o600)` can restrict them. This creates a split-second window (Time-of-Check to Time-of-Use) where sensitive data could be accessed.
🎯 Impact: Another local user could potentially read sensitive tokens (like LLM API keys) right as the settings file is created on a shared Unix system.
🔧 Fix: Replaced `std::fs::write` with `std::fs::OpenOptions` and `std::os::unix::fs::OpenOptionsExt::mode(0o600)` to securely guarantee the file is created with restricted permissions atomically. The `set_permissions` is kept as a fallback healing mechanism in case the file already existed with wider permissions.
✅ Verification: Isolated Rust tests run on a Linux-like environment confirmed the `test_settings.json` is accurately created with `-rw-------` (0o600) permissions using the updated method.

---
*PR created automatically by Jules for task [331794131720931517](https://jules.google.com/task/331794131720931517) started by @panda850819*