### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in settings file creation

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -120,7 +120,8 @@ impl Settings {
             self.hotkey_dictation = self.ptt_key.clone();
         }
         // translate_hotkey → hotkey_translate
-        if !self.translate_hotkey.is_empty() && self.hotkey_translate == default_hotkey_translate() {
+        if !self.translate_hotkey.is_empty() && self.hotkey_translate == default_hotkey_translate()
+        {
             self.hotkey_translate = self.translate_hotkey.clone();
         }
     }
@@ -430,8 +431,25 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
 
+    // Sentinel: Fix TOCTOU vulnerability
+    // Securely write file with restricted permissions natively to prevent a small
+    // window of time where sensitive data (e.g. API keys) can be read by others.
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+
+    let mut file = options.open(&path).map_err(|e| e.to_string())?;
+    use std::io::Write;
+    file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
+    file.flush().map_err(|e| e.to_string())?;
+
+    // Sentinel: Heal permissions if the file already existed and was truncated
     #[cfg(unix)]
     std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
         .map_err(|e| e.to_string())?;
@@ -539,7 +557,7 @@ mod tests {
         };
         let t = s.ptt_key_target();
         assert_eq!(t.modifier_mask, 0x20); // NX_DEVICELALTKEYMASK
-        assert_eq!(t.regular_key, 0x06);  // CGKeyCode for Z
+        assert_eq!(t.regular_key, 0x06); // CGKeyCode for Z
     }
 
     #[test]
@@ -563,7 +581,7 @@ mod tests {
         };
         let t = s.ptt_key_target();
         assert_eq!(t.modifier_mask, 0xA4); // VK_LMENU
-        assert_eq!(t.regular_key, 0x5A);   // VK_Z
+        assert_eq!(t.regular_key, 0x5A); // VK_Z
     }
 
     #[test]
@@ -583,7 +601,10 @@ mod tests {
             dictionary: "".to_string(),
             ..Settings::default()
         };
-        assert_eq!(s.whisper_initial_prompt(), "繁體中文語音轉錄，使用台灣正體中文。");
+        assert_eq!(
+            s.whisper_initial_prompt(),
+            "繁體中文語音轉錄，使用台灣正體中文。"
+        );
     }
 
     #[test]
@@ -593,7 +614,10 @@ mod tests {
             dictionary: "".to_string(),
             ..Settings::default()
         };
-        assert_eq!(s.whisper_initial_prompt(), "繁體中文語音轉錄，使用台灣正體中文。");
+        assert_eq!(
+            s.whisper_initial_prompt(),
+            "繁體中文語音轉錄，使用台灣正體中文。"
+        );
     }
 
     #[test]
@@ -623,7 +647,10 @@ mod tests {
             dictionary: "Hello World".to_string(),
             ..Settings::default()
         };
-        assert_eq!(s.whisper_initial_prompt(), "Hello World 繁體中文語音轉錄，使用台灣正體中文。");
+        assert_eq!(
+            s.whisper_initial_prompt(),
+            "Hello World 繁體中文語音轉錄，使用台灣正體中文。"
+        );
     }
 
     #[test]


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Time-of-Check to Time-of-Use (TOCTOU) vulnerability where `std::fs::write` creates the settings file with default/permissive file permissions before immediately applying `0o600` via `set_permissions`. This left a brief window where a file containing sensitive credentials (like `groq_api_key`) could be read by other local users on Unix systems.
🎯 Impact: Another user on the same system could potentially read sensitive API keys or configuration options stored in the settings JSON if they read the file in the split second before permissions are restricted.
🔧 Fix: Replaced `std::fs::write` with `std::fs::OpenOptions` and utilized `std::os::unix::fs::OpenOptionsExt`'s `.mode(0o600)` to ensure the file is created with restricted permissions from the very start, closing the TOCTOU window. We still apply `set_permissions` afterwards to heal permissions if the file already existed with wider permissions and was simply truncated.
✅ Verification: Code review and standalone Rust script verification of `OpenOptions` configuration.

---
*PR created automatically by Jules for task [4067214369055982427](https://jules.google.com/task/4067214369055982427) started by @panda850819*