### PR TITLE
🛡️ Sentinel: [High] Fix TOCTOU vulnerability in settings storage

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -430,8 +430,25 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
+
+    // Sentinel: Fix TOCTOU vulnerability by atomically creating file with secure permissions
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&path)
+            .map_err(|e| e.to_string())?;
+        file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
+    }
+    #[cfg(not(unix))]
     std::fs::write(&path, json).map_err(|e| e.to_string())?;
 
+    // Heal existing file permissions if truncate preserved wider permissions
     #[cfg(unix)]
     std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
         .map_err(|e| e.to_string())?;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The settings file, which contains sensitive API keys (e.g., groq_api_key), was previously created using `std::fs::write`. On Unix systems, this creates the file with default permissions before immediately running `std::fs::set_permissions(0o600)`. This leaves a brief Time-of-Check to Time-of-Use (TOCTOU) window where the file is readable by other local users.
🎯 Impact: A malicious local user could potentially read the sensitive API keys during the brief window before the file permissions are restricted.
🔧 Fix: Updated `save_settings` to use `std::fs::OpenOptions` with `std::os::unix::fs::OpenOptionsExt`'s `.mode(0o600)` to atomically create the file with restricted permissions. The existing `set_permissions` call is retained to 'heal' existing files if `truncate` preserves wider permissions.
✅ Verification: Code review and local testing confirmed that the atomic file creation correctly sets permissions to exactly 600 without a race condition.

---
*PR created automatically by Jules for task [16386023219277857800](https://jules.google.com/task/16386023219277857800) started by @panda850819*