### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in settings file creation

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -430,7 +430,22 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+
+    use std::io::Write;
+    let mut file = options.open(&path).map_err(|e| e.to_string())?;
+    file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
+
+    // Explicitly drop file handle to ensure write completes before permissions change
+    drop(file);
 
     #[cfg(unix)]
     std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Time-Of-Check to Time-Of-Use (TOCTOU) vulnerability where `settings.json` containing sensitive data (like API keys) is briefly created with default system wide-open permissions before being restricted to `0o600`.
🎯 **Impact:** Malicious local actors or competing background processes could potentially read the file and extract API keys or other sensitive configuration variables during the window before the permissions are tightened.
🔧 **Fix:** Replaced `std::fs::write` with `std::fs::OpenOptions` and `std::os::unix::fs::OpenOptionsExt`, leveraging `.mode(0o600)` to ensure the file is created atomically with restricted permissions. Also dropped the file handle before invoking `std::fs::set_permissions` to safely restrict pre-existing files without locking issues.
✅ **Verification:** Simulated reproduction using a standalone Cargo script in the isolated testing environment verified clean compilation, proper execution, and appropriate handling of file system scopes.

---
*PR created automatically by Jules for task [3089804806502739046](https://jules.google.com/task/3089804806502739046) started by @panda850819*