### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in settings file creation

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 
 fn default_true() -> bool {
@@ -430,7 +430,18 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+
+    #[cfg(unix)]
+    options.mode(0o600);
+
+    let mut file = options.open(&path).map_err(|e| e.to_string())?;
+
+    use std::io::Write;
+    file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
+    drop(file);
 
     #[cfg(unix)]
     std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `save_settings` function in `src-tauri/src/settings.rs` used `std::fs::write` to save sensitive configuration data (including API keys). This created the file with default permissions before immediately following up with a `std::fs::set_permissions(..., 0o600)`. This two-step process created a Time-of-Check to Time-of-Use (TOCTOU) vulnerability window where a malicious local actor could read the file before permissions were locked down.
🎯 **Impact:** If exploited, a local user could extract sensitive API keys and user configurations from the settings file during the brief race condition window.
🔧 **Fix:** Replaced `std::fs::write` with `std::fs::OpenOptions`. On Unix systems, leveraged `std::os::unix::fs::OpenOptionsExt` to explicitly set `.mode(0o600)` during the file open/creation process. This ensures the file is created atomically with restricted permissions, closing the race window. The file handle is explicitly dropped before running the fallback `set_permissions` call (which serves to "heal" existing files with wider permissions, as `truncate` preserves existing modes).
✅ **Verification:** Verified locally using an isolated Cargo MRE ensuring `save_settings` logic securely creates the file with 600 permissions, then drops the handle safely. 

---
*PR created automatically by Jules for task [6563492384957436653](https://jules.google.com/task/6563492384957436653) started by @panda850819*