### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in settings file creation

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 
 fn default_true() -> bool {
@@ -430,11 +430,31 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
 
     #[cfg(unix)]
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| e.to_string())?;
+    {
+        use std::io::Write;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&path)
+            .map_err(|e| e.to_string())?;
+        file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
+        // Explicitly drop file handle to ensure writes complete
+        drop(file);
+
+        // Truncate preserves existing file permissions, so we still need to set it
+        // to heal permissions if the file already existed with wider permissions.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+            .map_err(|e| e.to_string())?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&path, json).map_err(|e| e.to_string())?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL

💡 **Vulnerability:** 
The application stored sensitive settings (like API keys) using a naive `std::fs::write` approach followed by `std::fs::set_permissions(0o600)`. This created a Time-of-Check to Time-of-Use (TOCTOU) vulnerability where an attacker could read the sensitive data between the file creation and the permission change.

🎯 **Impact:**
An attacker or malicious process running on the same machine could theoretically monitor the filesystem for new file creation, open the `settings.json` file during the brief window before permissions are restricted, and read sensitive contents such as `groq_api_key`.

🔧 **Fix:**
Modified `save_settings` in `src-tauri/src/settings.rs` to use `std::fs::OpenOptions` combined with Unix-specific `OpenOptionsExt::mode(0o600)` to ensure atomic creation with restrictive permissions. Additionally, to handle cases where the file already exists with wider permissions (as `truncate` preserves them), the file handle is explicitly dropped to complete writes before calling `std::fs::set_permissions` to effectively "heal" the permissions.

✅ **Verification:**
1. Run `cargo check` and `cargo clippy` to ensure no syntax errors.
2. The logic was verified locally using an isolated scratchpad project to ensure that file permissions are set atomically and the code compiles safely across OS targets.

---
*PR created automatically by Jules for task [5363377175182167023](https://jules.google.com/task/5363377175182167023) started by @panda850819*