### PR TITLE
⚡ Bolt: [performance improvement] Avoid redundant string allocations in text replacements

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
+use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 
 fn default_true() -> bool {
@@ -200,13 +201,16 @@ impl Settings {
 
     /// Apply text replacement rules to the given text.
     pub fn apply_replacements(&self, text: &str) -> String {
-        let mut result = text.to_string();
+        let mut result: Cow<str> = Cow::Borrowed(text);
         for rule in &self.text_replacements {
             if rule.enabled && !rule.find.is_empty() {
-                result = result.replace(&rule.find, &rule.replace);
+                // Check if the pattern exists before allocating a new String via replace
+                if result.contains(&rule.find) {
+                    result = Cow::Owned(result.replace(&rule.find, &rule.replace));
+                }
             }
         }
-        result
+        result.into_owned()
     }
 
     /// Returns the whisper language code.


### PR DESCRIPTION
💡 **What**:
Optimized `apply_replacements` in `src-tauri/src/settings.rs` to use `std::borrow::Cow` instead of unconditionally allocating new `String` objects for every replacement rule check. Added a `.contains` check before executing `.replace()`.

🎯 **Why**:
The original implementation called `.to_string()` on the input right away, and then invoked `.replace()` for every enabled text replacement rule. `String::replace` unconditionally allocates a new heap string, even if the target substring (`rule.find`) is not present. If a user has many rules, this results in many unnecessary allocations and memory copies per text processing event, which is particularly inefficient for rules that rarely match.

📊 **Impact**:
Reduces heap allocations during text replacements. For inputs where no rules match, it reduces string allocations from `N + 1` (where N is the number of enabled rules) to exactly `1` allocation (the final `.into_owned()`).

🔬 **Measurement**:
Verified through isolated Rust logic testing that the `Cow` and `.contains` implementation perfectly mimics the existing functionality. Memory profile during active typing or voice transcription utilizing replacement rules will show significantly fewer `String` allocations.

---
*PR created automatically by Jules for task [7023477853314009234](https://jules.google.com/task/7023477853314009234) started by @panda850819*