### PR TITLE
🛡️ Sentinel: [Medium] Fix TOCTOU vulnerability in settings file creation

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -430,11 +430,29 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
 
     #[cfg(unix)]
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| e.to_string())?;
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&path)
+            .map_err(|e| e.to_string())?;
+        file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
+        drop(file);
+
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+            .map_err(|e| e.to_string())?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&path, json).map_err(|e| e.to_string())?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The application was vulnerable to a Time-of-Check to Time-of-Use (TOCTOU) race condition when saving user settings. The file `settings.json` (which can contain API keys and configuration data) was created using `std::fs::write` with default permissions, and subsequently restricted using `std::fs::set_permissions`. This left a tiny window where the file was readable to other local users before being secured.
🎯 **Impact:** Potential unauthorized local reading of sensitive settings like API keys or custom endpoints. While considered a lower risk in a local desktop context, it is bad security practice.
🔧 **Fix:** Refactored `save_settings` for Unix platforms to use `std::fs::OpenOptions` along with `std::os::unix::fs::OpenOptionsExt`'s `.mode(0o600)` to ensure the settings file is created atomically with restricted permissions. Also ensured the file handle is dropped before healing permissions if the file already exists.
✅ **Verification:** Verified via an isolated Rust script mirroring the logic, which compiles and successfully produces a `-rw-------` file. Code review approved the fix.

---
*PR created automatically by Jules for task [4424805274024163198](https://jules.google.com/task/4424805274024163198) started by @panda850819*