### PR TITLE
⚡ Bolt: [performance improvement] Optimize string replacements to avoid redundant allocations

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
+use std::borrow::Cow;
 
 fn default_true() -> bool {
     true
@@ -200,13 +201,19 @@ impl Settings {
 
     /// Apply text replacement rules to the given text.
     pub fn apply_replacements(&self, text: &str) -> String {
-        let mut result = text.to_string();
+        // [BOLT OPTIMIZATION] Use Cow to avoid allocating a new String initially if no rules match.
+        // Also check `.contains` before `.replace` to prevent redundant O(N) heap allocations
+        // for non-matching rules, as `str::replace` always allocates a new String in Rust.
+        let mut result: Cow<str> = Cow::Borrowed(text);
         for rule in &self.text_replacements {
             if rule.enabled && !rule.find.is_empty() {
-                result = result.replace(&rule.find, &rule.replace);
+                if result.contains(&rule.find) {
+                    let replaced = result.replace(&rule.find, &rule.replace);
+                    result = Cow::Owned(replaced);
+                }
             }
         }
-        result
+        result.into_owned()
     }
 
     /// Returns the whisper language code.

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -206,11 +206,9 @@ impl Settings {
         // for non-matching rules, as `str::replace` always allocates a new String in Rust.
         let mut result: Cow<str> = Cow::Borrowed(text);
         for rule in &self.text_replacements {
-            if rule.enabled && !rule.find.is_empty() {
-                if result.contains(&rule.find) {
-                    let replaced = result.replace(&rule.find, &rule.replace);
-                    result = Cow::Owned(replaced);
-                }
+            if rule.enabled && !rule.find.is_empty() && result.contains(&rule.find) {
+                let replaced = result.replace(&rule.find, &rule.replace);
+                result = Cow::Owned(replaced);
             }
         }
         result.into_owned()


### PR DESCRIPTION
💡 What: Optimized the `apply_replacements` function in `src-tauri/src/settings.rs` to use `std::borrow::Cow` instead of immediately allocating a new `String`. Added a `.contains` check to ensure `.replace` is only called (and heap memory allocated) when the pattern actually exists.

🎯 Why: In Rust, `str::replace` always allocates a new `String` and copies memory, even if the target substring isn't found. This caused N unnecessary memory allocations per invocation (where N = number of replacement rules), which is highly inefficient for text processing pipelines on the hot path. 

📊 Impact: Reduces heap allocations in `apply_replacements` from `O(N)` down to `O(M)` (where M is the number of *actual* matches). If no rules match, 0 allocations are performed during the loop.

🔬 Measurement: Run a benchmark or trace memory allocations in the hot path when applying multiple text replacement rules. Verify that zero heap allocations are triggered by the loop iteration for non-matching rules.

---
*PR created automatically by Jules for task [15944082537799623492](https://jules.google.com/task/15944082537799623492) started by @panda850819*