### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in settings save

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [Fix Time-of-Check to Time-of-Use (TOCTOU) during settings save]
+**Vulnerability:** A TOCTOU vulnerability was found in `save_settings` where `std::fs::write` was used to create the settings file containing sensitive API keys with default permissions, followed by a separate call to `std::fs::set_permissions` to restrict them.
+**Learning:** This leaves a race condition window where an attacker on the same machine could read the file before its permissions are secured.
+**Prevention:** Always use `std::fs::OpenOptions` with the `.mode(0o600)` builder method (via `std::os::unix::fs::OpenOptionsExt` on Unix) to create sensitive files atomically with the correct permissions from the start.

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 
 fn default_true() -> bool {
@@ -430,7 +430,17 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+
+    #[cfg(unix)]
+    options.mode(0o600);
+
+    use std::io::Write;
+    let mut file = options.open(&path).map_err(|e| e.to_string())?;
+    file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
+    drop(file);
 
     #[cfg(unix)]
     std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Time-of-Check to Time-of-Use (TOCTOU) during settings save. The settings file containing sensitive API keys was being created with default (less secure) permissions using `std::fs::write`, and only immediately afterwards restricted via `std::fs::set_permissions`.
🎯 Impact: This race condition creates a window where local attackers or other processes on the same machine might access the sensitive API keys before the permissions are tightened.
🔧 Fix: Used `std::fs::OpenOptions` chained with the Unix-specific `OpenOptionsExt::mode(0o600)` to atomically create the file with the strict permissions applied from the very start.
✅ Verification: Ran an isolated Rust cargo project verifying `OpenOptionsExt` correctly creates the file as `-rw-------`. Reviewed the code successfully.

---
*PR created automatically by Jules for task [9289574240081561761](https://jules.google.com/task/9289574240081561761) started by @panda850819*