### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in settings file creation

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
+use std::io::Write;
 
 fn default_true() -> bool {
     true
@@ -430,7 +431,17 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+
+    #[cfg(unix)]
+    options.mode(0o600);
+
+    let mut file = options.open(&path).map_err(|e| e.to_string())?;
+    file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
+
+    drop(file);
 
     #[cfg(unix)]
     std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The application settings (which contain sensitive user info like API keys) were saved by writing the file and then modifying its permissions. This creates a Time-Of-Check to Time-Of-Use (TOCTOU) race condition where a malicious process could access the file before it is secured.
🎯 **Impact:** Local privilege escalation or information disclosure, allowing other users on the system to read sensitive API keys and configuration if they access the file precisely between the write and the permission change.
🔧 **Fix:** Used `std::fs::OpenOptions` with the Unix-specific `.mode(0o600)` extension to atomically create the file with restricted permissions. Explictly dropped the file handle before attempting to heal permissions to preserve cross-platform compatibility.
✅ **Verification:** Verified by code review and isolated rust script compilation. `cargo check` confirms proper handling of `#[cfg(unix)]` attribute boundaries.

---
*PR created automatically by Jules for task [4752436657584574242](https://jules.google.com/task/4752436657584574242) started by @panda850819*