### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix TOCTOU vulnerability in settings file creation

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,4 +1,8 @@
 use serde::{Deserialize, Serialize};
+use std::fs::OpenOptions;
+use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
@@ -430,11 +434,31 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
 
     #[cfg(unix)]
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| e.to_string())?;
+    {
+        // 🛡️ Sentinel: Fix TOCTOU vulnerability by using atomic creation with secure permissions
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&path)
+            .map_err(|e| e.to_string())?;
+
+        file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
+
+        // Ensure file handle is dropped before healing permissions on existing files
+        drop(file);
+
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+            .map_err(|e| e.to_string())?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&path, json).map_err(|e| e.to_string())?;
+    }
 
     Ok(())
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
+#[cfg(unix)]
 use std::fs::OpenOptions;
+#[cfg(unix)]
 use std::io::Write;
 #[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt;


### PR DESCRIPTION
## 🛡️ Sentinel: [MEDIUM] Fix TOCTOU vulnerability in settings file creation

**Severity:** MEDIUM (Local single-user context, but handling API keys)
**Vulnerability:** Time-of-Check to Time-of-Use (TOCTOU) vulnerability during settings file saving. The code previously used `std::fs::write` to create the settings file and then `std::fs::set_permissions` to change the permissions to `0o600`. This created a race condition window where an attacker on a multi-user Unix system could theoretically read the file (which may contain API keys) before the permissions were restricted.
**Impact:** Potential leakage of API keys or custom LLM configurations to other local users.
**Fix:** Refactored `save_settings` to use `std::fs::OpenOptions` combined with `std::os::unix::fs::OpenOptionsExt::mode` for atomic file creation with secure `0o600` permissions on Unix platforms. 
**Verification:** Ran standalone compilation testing for the required `OpenOptions` syntax and ensured permissions accurately reflect `-rw-------` on creation. Code review confirmed safety and logic.

---
*PR created automatically by Jules for task [788671973672061189](https://jules.google.com/task/788671973672061189) started by @panda850819*