### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in settings file creation

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
+use std::io::Write;
 
 fn default_true() -> bool {
     true
@@ -430,7 +431,16 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+
+    #[cfg(unix)]
+    options.mode(0o600);
+
+    let mut file = options.open(&path).map_err(|e| e.to_string())?;
+    file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
+    drop(file);
 
     #[cfg(unix)]
     std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The settings file (`settings.json`) containing sensitive API keys (`groq_api_key`, `custom_llm_key`) was created with default OS permissions and then retrospectively restricted using `std::fs::set_permissions`. This left a brief window (Time-Of-Check to Time-Of-Use) where an unauthorized local process could read the contents.
🎯 **Impact**: Malicious local processes could steal API keys by watching the filesystem and grabbing the file contents before the permissions were updated.
🔧 **Fix**: Replaced `std::fs::write` with `std::fs::OpenOptions` and `.mode(0o600)` to ensure the settings file is atomically created with secure permissions. 
✅ **Verification**: Verified the change via isolated Rust compilation checking and static code review. Evaluated cross-platform safety using `#[cfg(unix)]`.

---
*PR created automatically by Jules for task [17322616576465334854](https://jules.google.com/task/17322616576465334854) started by @panda850819*