### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU file access vulnerability

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 
 fn default_true() -> bool {
@@ -430,7 +430,20 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+
+    #[cfg(unix)]
+    options.mode(0o600);
+
+    let mut file = options.open(&path).map_err(|e| e.to_string())?;
+    use std::io::Write;
+    file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
+    file.flush().map_err(|e| e.to_string())?;
+
+    // Drop the file explicitly to ensure it is closed before potentially touching permissions
+    drop(file);
 
     #[cfg(unix)]
     std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Time-of-Check to Time-of-Use (TOCTOU) file access race condition during settings saving. The application created the `settings.json` file with default (potentially world-readable) permissions before manually setting them to `0o600`. This left a brief window where sensitive settings (like API keys) could be read by other local users.
🎯 **Impact:** Exposure of sensitive user configurations (e.g., LLM provider API keys) to concurrent local processes or users.
🔧 **Fix:** Modified `src-tauri/src/settings.rs` to use `std::fs::OpenOptions` combined with `std::os::unix::fs::OpenOptionsExt`'s `.mode(0o600)` to atomically create the file with the secure permissions. The file is also explicitly flushed and dropped before fallback file permission healing.
✅ **Verification:** A standalone isolated Rust script was used to verify correct permission mapping on Unix and ensures the code compiles successfully.

---
*PR created automatically by Jules for task [1585745934623281429](https://jules.google.com/task/1585745934623281429) started by @panda850819*