### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in settings file creation

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 
 fn default_true() -> bool {
@@ -430,11 +430,30 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
 
     #[cfg(unix)]
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| e.to_string())?;
+    {
+        use std::io::Write;
+        // Atomically create the file with restricted permissions if it doesn't exist
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&path)
+            .map_err(|e| e.to_string())?;
+        file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
+        drop(file);
+
+        // Heal permissions on existing files
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+            .map_err(|e| e.to_string())?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&path, json).map_err(|e| e.to_string())?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `save_settings` function in `src-tauri/src/settings.rs` used `std::fs::write` to create the settings JSON file, followed by `std::fs::set_permissions` to restrict access. This created a Time-of-Check to Time-of-Use (TOCTOU) race condition where a malicious local process could open the file while it briefly had default, world-readable permissions, exposing sensitive data such as API keys.
🎯 **Impact:** Unauthorized local processes or users could read sensitive user configurations, including `groq_api_key` and other credentials.
🔧 **Fix:** Replaced the unsafe `std::fs::write` with `std::fs::OpenOptions`, utilizing `std::os::unix::fs::OpenOptionsExt`'s `.mode(0o600)` to atomically create the file with restricted permissions. Kept the subsequent `set_permissions` call to heal existing, potentially exposed files.
✅ **Verification:** Verified via code review and an isolated standalone Rust script testing the modified atomic file creation mechanism, confirming that the new file is created with `-rw-------` permissions.

---
*PR created automatically by Jules for task [15104063921637306174](https://jules.google.com/task/15104063921637306174) started by @panda850819*