### PR TITLE
⚡ Bolt: [performance improvement] Optimize text replacements allocation

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -203,11 +203,9 @@ impl Settings {
     pub fn apply_replacements(&self, text: &str) -> String {
         let mut result = Cow::Borrowed(text);
         for rule in &self.text_replacements {
-            if rule.enabled && !rule.find.is_empty() {
-                if result.contains(&rule.find) {
-                    // Cow::replace allocates a new String, so we wrap it in Cow::Owned.
-                    result = Cow::Owned(result.replace(&rule.find, &rule.replace));
-                }
+            if rule.enabled && !rule.find.is_empty() && result.contains(&rule.find) {
+                // Cow::replace allocates a new String, so we wrap it in Cow::Owned.
+                result = Cow::Owned(result.replace(&rule.find, &rule.replace));
             }
         }
         result.into_owned()

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
@@ -200,13 +201,16 @@ impl Settings {
 
     /// Apply text replacement rules to the given text.
     pub fn apply_replacements(&self, text: &str) -> String {
-        let mut result = text.to_string();
+        let mut result = Cow::Borrowed(text);
         for rule in &self.text_replacements {
             if rule.enabled && !rule.find.is_empty() {
-                result = result.replace(&rule.find, &rule.replace);
+                if result.contains(&rule.find) {
+                    // Cow::replace allocates a new String, so we wrap it in Cow::Owned.
+                    result = Cow::Owned(result.replace(&rule.find, &rule.replace));
+                }
             }
         }
-        result
+        result.into_owned()
     }
 
     /// Returns the whisper language code.


### PR DESCRIPTION
💡 What: Changed the `apply_replacements` function in `src-tauri/src/settings.rs` to use `std::borrow::Cow` and guarded `.replace()` with a `.contains()` check.

🎯 Why: Rust's `String::replace` allocates a new `String` every time it is called, even if the find pattern is not present. Since `apply_replacements` loops over all configured replacement rules, this previously caused `N + 1` heap allocations per text processing event, where `N` is the number of rules.

📊 Impact: Reduces memory allocations from `O(N)` to `O(1)` in the best and most common case (where no rules match or rules are sparse). The initial allocation is avoided entirely using Clone-on-Write (`Cow::Borrowed`), and intermediate strings are only allocated when a match is actually found.

🔬 Measurement: Reviewing the algorithm shows a drop from unconditional `text.to_string()` and `result.replace` allocations to conditional `Cow::Owned` allocations. The behavior can be tested by passing strings through `apply_replacements` when multiple replacement rules are defined but not triggered.

---
*PR created automatically by Jules for task [1603641431340724119](https://jules.google.com/task/1603641431340724119) started by @panda850819*