### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix TOCTOU vulnerability in settings write

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
+use std::io::Write;
 
 fn default_true() -> bool {
     true
@@ -430,7 +431,16 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+
+    #[cfg(unix)]
+    options.mode(0o600);
+
+    let mut file = options.open(&path).map_err(|e| e.to_string())?;
+    file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
+    drop(file);
 
     #[cfg(unix)]
     std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The application was creating the `settings.json` file using standard defaults, which typically inherit system umask permissions. On UNIX platforms, the process later called `std::fs::set_permissions` to lock the file down to `0o600`. This left a Time-Of-Check to Time-Of-Use (TOCTOU) race condition during which an attacker or malicious process could observe the file's contents before permissions were tightened, potentially leaking the user's API keys (e.g. `groq_api_key`).
🎯 **Impact:** If successfully exploited, a malicious local process or user could extract API keys from the application's configuration.
🔧 **Fix:** Changed `std::fs::write` to explicitly use `std::fs::OpenOptions` and its Unix-specific `.mode()` extension, ensuring the file is atomically created with restrictive permissions (`0o600`). Retained the `set_permissions` command as a fallback lock for existing files, after appropriately closing the file handle with `drop()`.
✅ **Verification:** Verified changes through standalone local Cargo tests simulating the `save_settings` Unix behavior to ensure permissions `-rw-------` are successfully applied, avoiding failures due to missing glib dependencies on workspace builds. Tested fallback and proper handle droppings.

---
*PR created automatically by Jules for task [10676201350881035609](https://jules.google.com/task/10676201350881035609) started by @panda850819*