### PR TITLE
🛡️ Sentinel: [security improvement] Secure atomic file creation for settings & remove test keys

### DIFF
--- a/src-tauri/src/llm.rs
+++ b/src-tauri/src/llm.rs
@@ -543,7 +543,7 @@ mod tests {
     fn test_create_enhancer_groq() {
         let s = Settings {
             llm_enabled: true,
-            groq_api_key: "gsk_test".to_string(),
+            groq_api_key: "placeholder".to_string(),
             llm_provider: "groq".to_string(),
             ..Default::default()
         };
@@ -683,7 +683,7 @@ mod tests {
     #[test]
     fn test_create_translator_groq() {
         let s = Settings {
-            groq_api_key: "gsk_test".to_string(),
+            groq_api_key: "placeholder".to_string(),
             llm_provider: "groq".to_string(),
             llm_enabled: false, // should still work
             ..Default::default()

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -430,11 +430,31 @@ pub(crate) fn save_settings(settings: &Settings, base: &Path) -> Result<(), Stri
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    std::fs::write(&path, json).map_err(|e| e.to_string())?;
 
     #[cfg(unix)]
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| e.to_string())?;
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        use std::io::Write;
+
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&path)
+            .map_err(|e| e.to_string())?;
+        file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
+        drop(file);
+
+        // Heal permissions on existing files
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+            .map_err(|e| e.to_string())?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&path, json).map_err(|e| e.to_string())?;
+    }
 
     Ok(())
 }
@@ -450,7 +470,7 @@ mod tests {
             "language": "auto",
             "engine": "local",
             "model": "large-v3-turbo",
-            "groq_api_key": "gsk_test",
+            "groq_api_key": "placeholder",
             "window_opacity": 0.78,
             "auto_start": false,
             "llm_enabled": true,


### PR DESCRIPTION
🚨 **Severity:** LOW (Local desktop application; limited concurrent actor risk, but defense-in-depth improvement)
💡 **Vulnerability:** `save_settings` in `settings.rs` wrote sensitive API keys to `settings.json` using `std::fs::write` (defaulting to world-readable `0644` permissions) before setting permissions to `0600`. This created a TOCTOU window where local processes could read the sensitive file.
🎯 **Impact:** Potential local exposure of API keys to other processes or users on the same machine during file writes.
🔧 **Fix:** Refactored `save_settings` to use `std::fs::OpenOptions` with `.mode(0o600)` on Unix, ensuring atomic file creation with restricted permissions. Also removed mock `gsk_` tokens in test files to prevent false positives from security scanners.
✅ **Verification:** Verified via isolated script execution that the file is created with `-rw-------` (`0600`) permissions cleanly. Git diff validated changes. Tests passing.

---
*PR created automatically by Jules for task [14804438405771842669](https://jules.google.com/task/14804438405771842669) started by @panda850819*